### PR TITLE
Поддержка UTF-8 в txt2gam, CMake для VS 2017+, обновление wxWidgets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,162 @@
+cmake_minimum_required(VERSION 3.15)
+project(qsp)
+
+if(NOT MSVC OR MSVC_TOOLSET_VERSION LESS 141)
+    message(FATAL_ERROR "Only Visual Studio 2017 and later are supported")
+endif()
+
+option(BUILD_QSPGUI "Build qspgui application")
+if(BUILD_QSPGUI)
+    set(QSP_SOURCES
+        qsp/actions.c
+        qsp/callbacks.c
+        qsp/codetools.c
+        qsp/coding.c
+        qsp/common.c
+        qsp/errors.c
+        qsp/game.c
+        qsp/locations.c
+        qsp/mathops.c
+        qsp/memwatch.c
+        qsp/menu.c
+        qsp/objects.c
+        qsp/playlist.c
+        qsp/regexp.c
+        qsp/statements.c
+        qsp/text.c
+        qsp/time.c
+        qsp/towlower.c
+        qsp/towupper.c
+        qsp/variables.c
+        qsp/variant.c
+        qsp/onig/regcomp.c
+        qsp/onig/regenc.c
+        qsp/onig/regerror.c
+        qsp/onig/regexec.c
+        qsp/onig/regparse.c
+        qsp/onig/regsyntax.c
+        qsp/onig/regtrav.c
+        qsp/onig/regversion.c
+        qsp/onig/st.c
+        qsp/onig/enc/ascii.c
+        qsp/onig/enc/cp1251.c
+        qsp/onig/enc/koi8_r.c
+        qsp/onig/enc/unicode.c
+        qsp/onig/enc/utf16_be.c
+        qsp/onig/enc/utf16_le.c
+        qsp/onig/enc/utf32_be.c
+        qsp/onig/enc/utf32_le.c
+        qsp/bindings/default/default_callbacks.c
+        qsp/bindings/default/default_control.c
+        qsp/bindings/default/default_callbacks.c
+        qsp/bindings/default/default_control.c
+        qsp/bindings/flash/flash_callbacks.c
+        qsp/bindings/flash/flash_platform.c
+        qsp/bindings/flash/flash_control.c
+        qsp/bindings/java/java_callbacks.c
+        qsp/bindings/java/java_platform.c
+        qsp/bindings/java/java_control.c
+        qsp/bindings/android/android_callbacks.c
+        qsp/bindings/android/android_platform.c
+        qsp/bindings/android/android_control.c
+        qsp/actions.h
+        qsp/bindings/qsp.h
+        qsp/callbacks.h
+        qsp/codetools.h
+        qsp/coding.h
+        qsp/common.h
+        qsp/declarations.h
+        qsp/errors.h
+        qsp/game.h
+        qsp/locations.h
+        qsp/mathops.h
+        qsp/memwatch.h
+        qsp/menu.h
+        qsp/objects.h
+        qsp/playlist.h
+        qsp/regexp.h
+        qsp/statements.h
+        qsp/text.h
+        qsp/time.h
+        qsp/variables.h
+        qsp/variant.h
+        qsp/onig/config.h
+        qsp/onig/oniguruma.h
+        qsp/onig/regenc.h
+        qsp/onig/regint.h
+        qsp/onig/regparse.h
+        qsp/onig/st.h
+        qsp/bindings/bindings_config.h
+        qsp/bindings/default/qsp_default.h
+        qsp/bindings/flash/flash.h
+        qsp/bindings/java/java.h
+        qsp/bindings/android/android.h
+    )
+    add_library(qsp SHARED ${QSP_SOURCES})
+    target_compile_definitions(qsp PRIVATE _CRT_SECURE_NO_WARNINGS _WIN _UNICODE EXPORT)
+
+    find_package(wxWidgets REQUIRED base core adv aui html)
+    include(${wxWidgets_USE_FILE})
+
+    add_library(fmod SHARED IMPORTED)
+    set(FMOD_DLL "${CMAKE_SOURCE_DIR}/players/classic/misc/win32/fmodex.dll")
+    set(FMOD_LIBRARY "${CMAKE_SOURCE_DIR}/players/classic/qspgui/misc/win32/libs/fmodex_vc.lib")
+    set_target_properties(fmod PROPERTIES IMPORTED_LOCATION ${FMOD_DLL} IMPORTED_IMPLIB ${FMOD_LIBRARY})
+
+    set(QSPGUI_SOURCES
+        players/classic/qspgui/src/animwin.cpp
+        players/classic/qspgui/src/app.cpp
+        players/classic/qspgui/src/callbacks_gui.cpp
+        players/classic/qspgui/src/comtools.cpp
+        players/classic/qspgui/src/frame.cpp
+        players/classic/qspgui/src/imgcanvas.cpp
+        players/classic/qspgui/src/initevent.cpp
+        players/classic/qspgui/src/inputbox.cpp
+        players/classic/qspgui/src/inputdlg.cpp
+        players/classic/qspgui/src/listbox.cpp
+        players/classic/qspgui/src/msgdlg.cpp
+        players/classic/qspgui/src/textbox.cpp
+        players/classic/qspgui/src/transhelper.cpp
+        players/classic/qspgui/src/animwin.h
+        players/classic/qspgui/src/app.h
+        players/classic/qspgui/src/callbacks_gui.h
+        players/classic/qspgui/src/comtools.h
+        players/classic/qspgui/src/fmod.h
+        players/classic/qspgui/src/fmod_codec.h
+        players/classic/qspgui/src/fmod_dsp.h
+        players/classic/qspgui/src/fmod_memoryinfo.h
+        players/classic/qspgui/src/frame.h
+        players/classic/qspgui/src/imgcanvas.h
+        players/classic/qspgui/src/initevent.h
+        players/classic/qspgui/src/inputbox.h
+        players/classic/qspgui/src/inputdlg.h
+        players/classic/qspgui/src/listbox.h
+        players/classic/qspgui/src/msgdlg.h
+        players/classic/qspgui/src/textbox.h
+        players/classic/qspgui/src/transhelper.h
+        players/classic/qspgui/misc/win32/rsc/res.rc
+    )
+    add_executable(qspgui WIN32 ${QSPGUI_SOURCES})
+    target_include_directories(qspgui PRIVATE qsp/bindings qsp/bindings/default)
+    target_link_libraries(qspgui qsp fmod ${wxWidgets_LIBRARIES})
+    configure_file("${CMAKE_SOURCE_DIR}/players/classic/qspgui/misc/icons/logo.ico" "${CMAKE_BINARY_DIR}/misc/icons/logo.ico" COPYONLY)
+endif()
+
+option(BUILD_TXT2GAM "Build txt2gam program")
+if(BUILD_TXT2GAM)
+    set(TXT2GAM_SOURCES
+        txt2gam/src/coding.c
+        txt2gam/src/locations.c
+        txt2gam/src/main.c
+        txt2gam/src/memwatch.c
+        txt2gam/src/text.c
+        txt2gam/src/coding.h
+        txt2gam/src/declarations.h
+        txt2gam/src/locations.h
+        txt2gam/src/main.h
+        txt2gam/src/memwatch.h
+        txt2gam/src/text.h
+    )
+    add_executable(txt2gam ${TXT2GAM_SOURCES})
+    target_compile_definitions(txt2gam PRIVATE _CRT_SECURE_NO_WARNINGS _UNICODE)
+endif()

--- a/players/aeroqsp/shell/src/AeroQSPFrame.cpp
+++ b/players/aeroqsp/shell/src/AeroQSPFrame.cpp
@@ -49,17 +49,17 @@ AeroQSPFrame::AeroQSPFrame( const wxString &currentPath, const wxString &filenam
 		wxMenuBar *menuBar = new wxMenuBar;
 		_fileMenu = new wxMenu;
 		_helpMenu = new wxMenu;
-		wxMenuItem *fileOpenItem = new wxMenuItem(_fileMenu, ID_OPENGAME, wxT("&Открыть...\tCtrl+O"));
-		wxMenuItem *exitItem = new wxMenuItem(_fileMenu, ID_EXIT, wxT("&Выход\tAlt+X"));
-		wxMenuItem *screenModeItem = new wxMenuItem(_fileMenu, ID_SCREEN_MODE, wxT("&Полноэкранный режим\tAlt+Enter"));
+		wxMenuItem *fileOpenItem = new wxMenuItem(_fileMenu, ID_OPENGAME, wxT("&РћС‚РєСЂС‹С‚СЊ...\tCtrl+O"));
+		wxMenuItem *exitItem = new wxMenuItem(_fileMenu, ID_EXIT, wxT("&Р’С‹С…РѕРґ\tAlt+X"));
+		wxMenuItem *screenModeItem = new wxMenuItem(_fileMenu, ID_SCREEN_MODE, wxT("&РџРѕР»РЅРѕСЌРєСЂР°РЅРЅС‹Р№ СЂРµР¶РёРј\tAlt+Enter"));
 		_fileMenu->Append(fileOpenItem);
 		_fileMenu->Append(screenModeItem);
 		_fileMenu->AppendSeparator();
 		_fileMenu->Append(exitItem);
-		wxMenuItem *about = new wxMenuItem(_helpMenu, ID_ABOUT, wxT("&О программе..."));
+		wxMenuItem *about = new wxMenuItem(_helpMenu, ID_ABOUT, wxT("&Рћ РїСЂРѕРіСЂР°РјРјРµ..."));
 		_helpMenu->Append(about);
-		menuBar->Append(_fileMenu, wxT("&Игра"));
-		menuBar->Append(_helpMenu, wxT("&Помощь"));
+		menuBar->Append(_fileMenu, wxT("&РРіСЂР°"));
+		menuBar->Append(_helpMenu, wxT("&РџРѕРјРѕС‰СЊ"));
 		SetMenuBar(menuBar);
 		SetClientSize(800, 600);
 		CenterOnParent();
@@ -122,8 +122,8 @@ void AeroQSPFrame::SetUserTitle( const wxString &title )
 
 void AeroQSPFrame::OnLoadFile( wxCommandEvent &event )
 {
-	wxFileDialog dialog(this, wxT("Открыть игру"), wxEmptyString, wxEmptyString,
-		wxT("Игры AeroQSP (*.aqsp)|*.aqsp"), wxFD_OPEN);
+	wxFileDialog dialog(this, wxT("РћС‚РєСЂС‹С‚СЊ РёРіСЂСѓ"), wxEmptyString, wxEmptyString,
+		wxT("РРіСЂС‹ AeroQSP (*.aqsp)|*.aqsp"), wxFD_OPEN);
 	dialog.CenterOnParent();
 	if (dialog.ShowModal() == wxID_OK)
 		LoadFile(dialog.GetPath());

--- a/players/classic/build_wx/wxPatch-git.diff
+++ b/players/classic/build_wx/wxPatch-git.diff
@@ -16,7 +16,7 @@
  15 files changed, 190 insertions(+), 16 deletions(-)
 
 diff --git a/include/wx/animate.h b/include/wx/animate.h
-index 6243fb4..b88257a 100644
+index 6243fb4568..b88257abf9 100644
 --- a/include/wx/animate.h
 +++ b/include/wx/animate.h
 @@ -114,11 +114,15 @@ private:
@@ -36,7 +36,7 @@ index 6243fb4..b88257a 100644
  #endif // wxUSE_ANIMATIONCTRL
  
 diff --git a/include/wx/animdecod.h b/include/wx/animdecod.h
-index 58177e6..42451ab 100644
+index 58177e68fd..42451abf5f 100644
 --- a/include/wx/animdecod.h
 +++ b/include/wx/animdecod.h
 @@ -144,6 +144,9 @@ public:
@@ -50,7 +50,7 @@ index 58177e6..42451ab 100644
      wxSize GetAnimationSize() const { return m_szAnimation; }
      wxColour GetBackgroundColour() const { return m_background; }
 diff --git a/include/wx/aui/floatpane.h b/include/wx/aui/floatpane.h
-index bf15893..f773185 100644
+index bf158933b8..f77318576b 100644
 --- a/include/wx/aui/floatpane.h
 +++ b/include/wx/aui/floatpane.h
 @@ -31,6 +31,8 @@
@@ -79,7 +79,7 @@ index bf15893..f773185 100644
      void SetPaneWindow(const wxAuiPaneInfo& pane);
      wxAuiManager* GetOwnerManager() const;
 diff --git a/include/wx/generic/animate.h b/include/wx/generic/animate.h
-index 818daf8..2b97aaa 100644
+index 818daf890c..2b97aaa521 100644
 --- a/include/wx/generic/animate.h
 +++ b/include/wx/generic/animate.h
 @@ -26,8 +26,13 @@ public:
@@ -110,11 +110,11 @@ index 818daf8..2b97aaa 100644
      typedef wxAnimationCtrlBase base_type;
      DECLARE_DYNAMIC_CLASS(wxAnimationCtrl)
 diff --git a/include/wx/gifdecod.h b/include/wx/gifdecod.h
-index b0de466..273e029 100644
+index f0b84fc4bf..87286b2a09 100644
 --- a/include/wx/gifdecod.h
 +++ b/include/wx/gifdecod.h
 @@ -65,8 +65,11 @@ public:
-     virtual long GetDelay(unsigned int frame) const wxOVERRIDE;
+     virtual long GetDelay(unsigned int frame) const;
  
      // GIFs can contain both static images and animations
 +    // HzD_Byte's hack
@@ -126,7 +126,7 @@ index b0de466..273e029 100644
      // load function which returns more info than just Load():
      wxGIFErrorCode LoadGIF( wxInputStream& stream );
 diff --git a/include/wx/htmllbox.h b/include/wx/htmllbox.h
-index c7e27ee..dad79f3 100644
+index 27c3a36c30..2473d6700d 100644
 --- a/include/wx/htmllbox.h
 +++ b/include/wx/htmllbox.h
 @@ -129,7 +129,8 @@ protected:
@@ -137,8 +137,8 @@ index c7e27ee..dad79f3 100644
 +    // HzD_Byte's hack
 +// private:
      // wxHtmlWindowInterface methods:
-     virtual void SetHTMLWindowTitle(const wxString& title) wxOVERRIDE;
-     virtual void OnHTMLLinkClicked(const wxHtmlLinkInfo& link) wxOVERRIDE;
+     virtual void SetHTMLWindowTitle(const wxString& title);
+     virtual void OnHTMLLinkClicked(const wxHtmlLinkInfo& link);
 @@ -162,7 +163,8 @@ private:
      // given cell to physical coordinates in the window
      wxPoint CellCoordsToPhysical(const wxPoint& pos, wxHtmlCell *cell) const;
@@ -159,7 +159,7 @@ index c7e27ee..dad79f3 100644
      // it calls our GetSelectedTextColour() and GetSelectedTextBgColour()
      friend class wxHtmlListBoxStyle;
 diff --git a/src/aui/floatpane.cpp b/src/aui/floatpane.cpp
-index 837c0a0..176a0f9 100644
+index 837c0a0aa5..176a0f9316 100644
 --- a/src/aui/floatpane.cpp
 +++ b/src/aui/floatpane.cpp
 @@ -132,10 +132,13 @@ void wxAuiFloatingFrame::SetPaneWindow(const wxAuiPaneInfo& pane)
@@ -177,7 +177,7 @@ index 837c0a0..176a0f9 100644
      if ( hasFloatingSize )
      {
 diff --git a/src/aui/framemanager.cpp b/src/aui/framemanager.cpp
-index 8f92365..15dfb9d 100644
+index f0c506220d..4a8cd4ebf5 100644
 --- a/src/aui/framemanager.cpp
 +++ b/src/aui/framemanager.cpp
 @@ -2670,6 +2670,8 @@ void wxAuiManager::Update()
@@ -190,7 +190,7 @@ index 8f92365..15dfb9d 100644
      }
  
 diff --git a/src/common/filesys.cpp b/src/common/filesys.cpp
-index fadcec6..8dc1d61 100644
+index 06edca28a2..14663e4857 100644
 --- a/src/common/filesys.cpp
 +++ b/src/common/filesys.cpp
 @@ -632,7 +632,8 @@ wxFileName wxFileSystem::URLToFileName(const wxString& url)
@@ -204,7 +204,7 @@ index fadcec6..8dc1d61 100644
  #ifdef __WINDOWS__
      // file urls either start with a forward slash (local harddisk),
 diff --git a/src/generic/animateg.cpp b/src/generic/animateg.cpp
-index d238c82..66173e5 100644
+index dd2adecffc..85391aabb7 100644
 --- a/src/generic/animateg.cpp
 +++ b/src/generic/animateg.cpp
 @@ -276,6 +276,8 @@ void wxAnimationCtrl::Init()
@@ -304,10 +304,10 @@ index d238c82..66173e5 100644
  }
  
 diff --git a/src/generic/scrlwing.cpp b/src/generic/scrlwing.cpp
-index ff248ce..7cdaad6 100644
+index 4fcb6a17bf..c34de2b419 100644
 --- a/src/generic/scrlwing.cpp
 +++ b/src/generic/scrlwing.cpp
-@@ -558,6 +558,8 @@ void wxScrollHelperBase::HandleOnScroll(wxScrollWinEvent& event)
+@@ -608,6 +608,8 @@ void wxScrollHelperBase::HandleOnScroll(wxScrollWinEvent& event)
          m_win->SetScrollPos(wxVERTICAL, m_yScrollPosition);
      }
  
@@ -316,7 +316,7 @@ index ff248ce..7cdaad6 100644
      if ( needsRefresh )
      {
          m_targetWindow->Refresh(true, GetScrollRect());
-@@ -566,6 +568,10 @@ void wxScrollHelperBase::HandleOnScroll(wxScrollWinEvent& event)
+@@ -616,6 +618,10 @@ void wxScrollHelperBase::HandleOnScroll(wxScrollWinEvent& event)
      {
          m_targetWindow->ScrollWindow(dx, dy, GetScrollRect());
      }
@@ -328,21 +328,21 @@ index ff248ce..7cdaad6 100644
  
  int wxScrollHelperBase::CalcScrollInc(wxScrollWinEvent& event)
 diff --git a/src/html/htmlwin.cpp b/src/html/htmlwin.cpp
-index 21fdad2..afd7a2f 100644
+index 01621ddf5d..7b6292548e 100644
 --- a/src/html/htmlwin.cpp
 +++ b/src/html/htmlwin.cpp
-@@ -482,7 +482,8 @@ bool wxHtmlWindow::DoSetPage(const wxString& source)
+@@ -472,7 +472,8 @@ bool wxHtmlWindow::DoSetPage(const wxString& source)
      // ...and run the parser on it:
-     wxClientDC *dc = new wxClientDC(this);
-     dc->SetMapMode(wxMM_TEXT);
+     wxClientDC dc(this);
+     dc.SetMapMode(wxMM_TEXT);
 -    SetBackgroundColour(wxColour(0xFF, 0xFF, 0xFF));
 +    // HzD_Byte's hack
 +    // SetBackgroundColour(wxColour(0xFF, 0xFF, 0xFF));
      SetBackgroundImage(wxNullBitmap);
  
-     m_Parser->SetDC(dc);
+     m_Parser->SetDC(&dc);
 diff --git a/src/html/m_image.cpp b/src/html/m_image.cpp
-index d16040f..f8e41c4 100644
+index 482692b649..b90ba0fdbc 100644
 --- a/src/html/m_image.cpp
 +++ b/src/html/m_image.cpp
 @@ -311,6 +311,9 @@ private:
@@ -546,7 +546,7 @@ index d16040f..f8e41c4 100644
  
  wxHtmlLinkInfo *wxHtmlImageCell::GetLink( int x, int y ) const
 diff --git a/src/html/m_links.cpp b/src/html/m_links.cpp
-index b5a6553..ba2696a 100644
+index 4dfebdc2e6..9f595b85c5 100644
 --- a/src/html/m_links.cpp
 +++ b/src/html/m_links.cpp
 @@ -84,7 +84,10 @@ TAG_HANDLER_BEGIN(A, "A")
@@ -562,7 +562,7 @@ index b5a6553..ba2696a 100644
              m_WParser->SetLink(wxHtmlLinkInfo(href, target));
  
 diff --git a/src/html/winpars.cpp b/src/html/winpars.cpp
-index 9973cf1..c3f8d6a 100644
+index 1218467ba3..95df9bbb42 100644
 --- a/src/html/winpars.cpp
 +++ b/src/html/winpars.cpp
 @@ -55,6 +55,8 @@ wxHtmlWinParser::wxHtmlWinParser(wxHtmlWindowInterface *wndIface)
@@ -584,7 +584,7 @@ index 9973cf1..c3f8d6a 100644
      m_ActualColor.Set(0, 0, 0);
      const wxColour windowColour = wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOW) ;
      m_ActualBackgroundColor = m_windowInterface
-@@ -291,6 +294,8 @@ wxFSFile *wxHtmlWinParser::OpenURL(wxHtmlURLType type,
+@@ -300,6 +303,8 @@ wxFSFile *wxHtmlWinParser::OpenURL(wxHtmlURLType type,
      {
          wxString myfullurl(myurl);
  
@@ -593,7 +593,7 @@ index 9973cf1..c3f8d6a 100644
          // consider url as absolute path first
          wxURI current(myurl);
          myfullurl = current.BuildUnescapedURI();
-@@ -319,6 +324,7 @@ wxFSFile *wxHtmlWinParser::OpenURL(wxHtmlURLType type,
+@@ -328,6 +333,7 @@ wxFSFile *wxHtmlWinParser::OpenURL(wxHtmlURLType type,
                  }
              }
          }

--- a/players/classic/qspgui/src/frame.cpp
+++ b/players/classic/qspgui/src/frame.cpp
@@ -913,7 +913,6 @@ void QSPFrame::OnAbout(wxCommandEvent& event)
 	info.AddArtist(wxT("AI [gribanov_a@mail.ru]"));
 	info.AddArtist(wxT("Ajenta [ajenta.arrow@gmail.com]"));
 	info.AddArtist(wxT("Alex [dogmar88@mail.ru]"));
-	info.AddArtist(wxT("BalleR [vsevolod_kremyan@mail.ru]"));
 	info.AddArtist(wxT("BaxZzZz [bauer_v@mail.ru]"));
 	info.AddArtist(wxT("Belial [belgame@bk.ru]"));
 	info.AddArtist(wxT("DzafT [dzaft@mail.ru]"));

--- a/qsp/bindings/android/android_callbacks.c
+++ b/qsp/bindings/android/android_callbacks.c
@@ -43,7 +43,7 @@ void qspSetCallBack(int type, QSP_CALLBACK func)
 
 void qspCallDebug(QSP_CHAR *str)
 {
-	/* Здесь передаем управление отладчику */
+	/* Р—РґРµСЃСЊ РїРµСЂРµРґР°РµРј СѓРїСЂР°РІР»РµРЅРёРµ РѕС‚Р»Р°РґС‡РёРєСѓ */
 	QSPCallState state;
 	if (qspCallBacks[QSP_CALL_DEBUG])
 	{
@@ -55,7 +55,7 @@ void qspCallDebug(QSP_CHAR *str)
 
 void qspCallSetTimer(int msecs)
 {
-	/* Здесь устанавливаем интервал таймера */
+	/* Р—РґРµСЃСЊ СѓСЃС‚Р°РЅР°РІР»РёРІР°РµРј РёРЅС‚РµСЂРІР°Р» С‚Р°Р№РјРµСЂР° */
 	QSPCallState state;
 	if (qspCallBacks[QSP_CALL_SETTIMER])
 	{
@@ -67,7 +67,7 @@ void qspCallSetTimer(int msecs)
 
 void qspCallRefreshInt(QSP_BOOL isRedraw)
 {
-	/* Здесь выполняем обновление интерфейса */
+	/* Р—РґРµСЃСЊ РІС‹РїРѕР»РЅСЏРµРј РѕР±РЅРѕРІР»РµРЅРёРµ РёРЅС‚РµСЂС„РµР№СЃР° */
 	QSPCallState state;
 	if (qspCallBacks[QSP_CALL_REFRESHINT])
 	{
@@ -79,7 +79,7 @@ void qspCallRefreshInt(QSP_BOOL isRedraw)
 
 void qspCallSetInputStrText(QSP_CHAR *text)
 {
-	/* Здесь устанавливаем текст строки ввода */
+	/* Р—РґРµСЃСЊ СѓСЃС‚Р°РЅР°РІР»РёРІР°РµРј С‚РµРєСЃС‚ СЃС‚СЂРѕРєРё РІРІРѕРґР° */
 	QSPCallState state;
 	if (qspCallBacks[QSP_CALL_SETINPUTSTRTEXT])
 	{
@@ -91,7 +91,7 @@ void qspCallSetInputStrText(QSP_CHAR *text)
 
 void qspCallAddMenuItem(QSP_CHAR *name, QSP_CHAR *imgPath)
 {
-	/* Здесь добавляем пункт меню */
+	/* Р—РґРµСЃСЊ РґРѕР±Р°РІР»СЏРµРј РїСѓРЅРєС‚ РјРµРЅСЋ */
 	QSPCallState state;
 	if (qspCallBacks[QSP_CALL_ADDMENUITEM])
 	{
@@ -103,7 +103,7 @@ void qspCallAddMenuItem(QSP_CHAR *name, QSP_CHAR *imgPath)
 
 void qspCallSystem(QSP_CHAR *cmd)
 {
-	/* Здесь выполняем системный вызов */
+	/* Р—РґРµСЃСЊ РІС‹РїРѕР»РЅСЏРµРј СЃРёСЃС‚РµРјРЅС‹Р№ РІС‹Р·РѕРІ */
 	QSPCallState state;
 	if (qspCallBacks[QSP_CALL_SYSTEM])
 	{
@@ -115,8 +115,8 @@ void qspCallSystem(QSP_CHAR *cmd)
 
 void qspCallOpenGameStatus(QSP_CHAR *file)
 {
-	/* Здесь позволяем пользователю выбрать файл */
-	/* состояния игры для загрузки и загружаем его */
+	/* Р—РґРµСЃСЊ РїРѕР·РІРѕР»СЏРµРј РїРѕР»СЊР·РѕРІР°С‚РµР»СЋ РІС‹Р±СЂР°С‚СЊ С„Р°Р№Р» */
+	/* СЃРѕСЃС‚РѕСЏРЅРёСЏ РёРіСЂС‹ РґР»СЏ Р·Р°РіСЂСѓР·РєРё Рё Р·Р°РіСЂСѓР¶Р°РµРј РµРіРѕ */
 	QSPCallState state;
 	if (qspCallBacks[QSP_CALL_OPENGAMESTATUS])
 	{
@@ -128,9 +128,9 @@ void qspCallOpenGameStatus(QSP_CHAR *file)
 
 void qspCallSaveGameStatus(QSP_CHAR *file)
 {
-	/* Здесь позволяем пользователю выбрать файл */
-	/* для сохранения состояния игры и сохраняем */
-	/* в нем текущее состояние */
+	/* Р—РґРµСЃСЊ РїРѕР·РІРѕР»СЏРµРј РїРѕР»СЊР·РѕРІР°С‚РµР»СЋ РІС‹Р±СЂР°С‚СЊ С„Р°Р№Р» */
+	/* РґР»СЏ СЃРѕС…СЂР°РЅРµРЅРёСЏ СЃРѕСЃС‚РѕСЏРЅРёСЏ РёРіСЂС‹ Рё СЃРѕС…СЂР°РЅСЏРµРј */
+	/* РІ РЅРµРј С‚РµРєСѓС‰РµРµ СЃРѕСЃС‚РѕСЏРЅРёРµ */
 	QSPCallState state;
 	if (qspCallBacks[QSP_CALL_SAVEGAMESTATUS])
 	{
@@ -142,7 +142,7 @@ void qspCallSaveGameStatus(QSP_CHAR *file)
 
 void qspCallShowMessage(QSP_CHAR *text)
 {
-	/* Здесь показываем сообщение */
+	/* Р—РґРµСЃСЊ РїРѕРєР°Р·С‹РІР°РµРј СЃРѕРѕР±С‰РµРЅРёРµ */
 	QSPCallState state;
 	if (qspCallBacks[QSP_CALL_SHOWMSGSTR])
 	{
@@ -154,7 +154,7 @@ void qspCallShowMessage(QSP_CHAR *text)
 
 int qspCallShowMenu()
 {
-	/* Здесь показываем меню */
+	/* Р—РґРµСЃСЊ РїРѕРєР°Р·С‹РІР°РµРј РјРµРЅСЋ */
 	QSPCallState state;
 	int index;
 	if (qspCallBacks[QSP_CALL_SHOWMENU])
@@ -169,7 +169,7 @@ int qspCallShowMenu()
 
 void qspCallShowPicture(QSP_CHAR *file)
 {
-	/* Здесь показываем изображение */
+	/* Р—РґРµСЃСЊ РїРѕРєР°Р·С‹РІР°РµРј РёР·РѕР±СЂР°Р¶РµРЅРёРµ */
 	QSPCallState state;
 	if (qspCallBacks[QSP_CALL_SHOWIMAGE])
 	{
@@ -181,7 +181,7 @@ void qspCallShowPicture(QSP_CHAR *file)
 
 void qspCallShowWindow(int type, QSP_BOOL isShow)
 {
-	/* Здесь показываем или скрываем окно */
+	/* Р—РґРµСЃСЊ РїРѕРєР°Р·С‹РІР°РµРј РёР»Рё СЃРєСЂС‹РІР°РµРј РѕРєРЅРѕ */
 	QSPCallState state;
 	if (qspCallBacks[QSP_CALL_SHOWWINDOW])
 	{
@@ -193,7 +193,7 @@ void qspCallShowWindow(int type, QSP_BOOL isShow)
 
 void qspCallPlayFile(QSP_CHAR *file, int volume)
 {
-	/* Здесь начинаем воспроизведение файла с заданной громкостью */
+	/* Р—РґРµСЃСЊ РЅР°С‡РёРЅР°РµРј РІРѕСЃРїСЂРѕРёР·РІРµРґРµРЅРёРµ С„Р°Р№Р»Р° СЃ Р·Р°РґР°РЅРЅРѕР№ РіСЂРѕРјРєРѕСЃС‚СЊСЋ */
 	QSPCallState state;
 	if (qspCallBacks[QSP_CALL_PLAYFILE])
 	{
@@ -205,7 +205,7 @@ void qspCallPlayFile(QSP_CHAR *file, int volume)
 
 QSP_BOOL qspCallIsPlayingFile(QSP_CHAR *file)
 {
-	/* Здесь проверяем, проигрывается ли файл */
+	/* Р—РґРµСЃСЊ РїСЂРѕРІРµСЂСЏРµРј, РїСЂРѕРёРіСЂС‹РІР°РµС‚СЃСЏ Р»Рё С„Р°Р№Р» */
 	QSPCallState state;
 	QSP_BOOL isPlaying;
 	if (qspCallBacks[QSP_CALL_ISPLAYINGFILE])
@@ -220,7 +220,7 @@ QSP_BOOL qspCallIsPlayingFile(QSP_CHAR *file)
 
 void qspCallSleep(int msecs)
 {
-	/* Здесь ожидаем заданное количество миллисекунд */
+	/* Р—РґРµСЃСЊ РѕР¶РёРґР°РµРј Р·Р°РґР°РЅРЅРѕРµ РєРѕР»РёС‡РµСЃС‚РІРѕ РјРёР»Р»РёСЃРµРєСѓРЅРґ */
 	QSPCallState state;
 	if (qspCallBacks[QSP_CALL_SLEEP])
 	{
@@ -232,7 +232,7 @@ void qspCallSleep(int msecs)
 
 int qspCallGetMSCount()
 {
-	/* Здесь получаем количество миллисекунд, прошедших с момента последнего вызова функции */
+	/* Р—РґРµСЃСЊ РїРѕР»СѓС‡Р°РµРј РєРѕР»РёС‡РµСЃС‚РІРѕ РјРёР»Р»РёСЃРµРєСѓРЅРґ, РїСЂРѕС€РµРґС€РёС… СЃ РјРѕРјРµРЅС‚Р° РїРѕСЃР»РµРґРЅРµРіРѕ РІС‹Р·РѕРІР° С„СѓРЅРєС†РёРё */
 	QSPCallState state;
 	int count;
 	if (qspCallBacks[QSP_CALL_GETMSCOUNT])
@@ -247,7 +247,7 @@ int qspCallGetMSCount()
 
 void qspCallCloseFile(QSP_CHAR *file)
 {
-	/* Здесь выполняем закрытие файла */
+	/* Р—РґРµСЃСЊ РІС‹РїРѕР»РЅСЏРµРј Р·Р°РєСЂС‹С‚РёРµ С„Р°Р№Р»Р° */
 	QSPCallState state;
 	if (qspCallBacks[QSP_CALL_CLOSEFILE])
 	{
@@ -259,7 +259,7 @@ void qspCallCloseFile(QSP_CHAR *file)
 
 void qspCallDeleteMenu()
 {
-	/* Здесь удаляем текущее меню */
+	/* Р—РґРµСЃСЊ СѓРґР°Р»СЏРµРј С‚РµРєСѓС‰РµРµ РјРµРЅСЋ */
 	QSPCallState state;
 	if (qspCallBacks[QSP_CALL_DELETEMENU])
 	{
@@ -271,7 +271,7 @@ void qspCallDeleteMenu()
 
 QSPString qspCallInputBox(QSPString text)
 {
-	/* Здесь вводим текст */
+	/* Р—РґРµСЃСЊ РІРІРѕРґРёРј С‚РµРєСЃС‚ */
 	QSPCallState state;
 	QSP_CHAR *buffer;
 	int maxLen = 511;

--- a/qsp/bindings/android/android_control.c
+++ b/qsp/bindings/android/android_control.c
@@ -41,14 +41,14 @@ QSP_BOOL QSPIsInCallBack()
 	return qspIsInCallBack;
 }
 /* ------------------------------------------------------------ */
-/* Отладка */
+/* РћС‚Р»Р°РґРєР° */
 
-/* Управление режимом отладки */
+/* РЈРїСЂР°РІР»РµРЅРёРµ СЂРµР¶РёРјРѕРј РѕС‚Р»Р°РґРєРё */
 void QSPEnableDebugMode(QSP_BOOL isDebug)
 {
 	qspIsDebug = isDebug;
 }
-/* Получение данных текущего состояния */
+/* РџРѕР»СѓС‡РµРЅРёРµ РґР°РЅРЅС‹С… С‚РµРєСѓС‰РµРіРѕ СЃРѕСЃС‚РѕСЏРЅРёСЏ */
 void QSPGetCurStateData(QSP_CHAR **loc, int *actIndex, int *line)
 {
 	*loc = (qspRealCurLoc >= 0 && qspRealCurLoc < qspLocsCount ? qspLocs[qspRealCurLoc].Name : 0);
@@ -56,64 +56,64 @@ void QSPGetCurStateData(QSP_CHAR **loc, int *actIndex, int *line)
 	*line = qspRealLine;
 }
 /* ------------------------------------------------------------ */
-/* Информация о версии */
+/* РРЅС„РѕСЂРјР°С†РёСЏ Рѕ РІРµСЂСЃРёРё */
 
-/* Версия */
+/* Р’РµСЂСЃРёСЏ */
 const QSP_CHAR *QSPGetVersion()
 {
 	return QSP_VER;
 }
-/* Дата и время компиляции */
+/* Р”Р°С‚Р° Рё РІСЂРµРјСЏ РєРѕРјРїРёР»СЏС†РёРё */
 const QSP_CHAR *QSPGetCompiledDateTime()
 {
 	return QSP_FMT(__DATE__) QSP_FMT(", ") QSP_FMT(__TIME__);
 }
 /* ------------------------------------------------------------ */
-/* Количество полных обновлений локаций */
+/* РљРѕР»РёС‡РµСЃС‚РІРѕ РїРѕР»РЅС‹С… РѕР±РЅРѕРІР»РµРЅРёР№ Р»РѕРєР°С†РёР№ */
 int QSPGetFullRefreshCount()
 {
 	return qspFullRefreshCount;
 }
 /* ------------------------------------------------------------ */
-/* Полный путь к загруженному файлу игры */
+/* РџРѕР»РЅС‹Р№ РїСѓС‚СЊ Рє Р·Р°РіСЂСѓР¶РµРЅРЅРѕРјСѓ С„Р°Р№Р»Сѓ РёРіСЂС‹ */
 const QSP_CHAR *QSPGetQstFullPath()
 {
 	return qspQstFullPath;
 }
 /* ------------------------------------------------------------ */
-/* Название текущей локации */
+/* РќР°Р·РІР°РЅРёРµ С‚РµРєСѓС‰РµР№ Р»РѕРєР°С†РёРё */
 const QSP_CHAR *QSPGetCurLoc()
 {
 	return (qspCurLoc >= 0 ? qspLocs[qspCurLoc].Name : 0);
 }
 /* ------------------------------------------------------------ */
-/* Основное описание локации */
+/* РћСЃРЅРѕРІРЅРѕРµ РѕРїРёСЃР°РЅРёРµ Р»РѕРєР°С†РёРё */
 
-/* Текст основного окна описания локации */
+/* РўРµРєСЃС‚ РѕСЃРЅРѕРІРЅРѕРіРѕ РѕРєРЅР° РѕРїРёСЃР°РЅРёСЏ Р»РѕРєР°С†РёРё */
 const QSP_CHAR *QSPGetMainDesc()
 {
 	return qspCurDesc;
 }
-/* Возможность изменения текста основного описания */
+/* Р’РѕР·РјРѕР¶РЅРѕСЃС‚СЊ РёР·РјРµРЅРµРЅРёСЏ С‚РµРєСЃС‚Р° РѕСЃРЅРѕРІРЅРѕРіРѕ РѕРїРёСЃР°РЅРёСЏ */
 QSP_BOOL QSPIsMainDescChanged()
 {
 	return qspIsMainDescChanged;
 }
 /* ------------------------------------------------------------ */
-/* Дополнительное описание локации */
+/* Р”РѕРїРѕР»РЅРёС‚РµР»СЊРЅРѕРµ РѕРїРёСЃР°РЅРёРµ Р»РѕРєР°С†РёРё */
 
-/* Текст дополнительного окна описания локации */
+/* РўРµРєСЃС‚ РґРѕРїРѕР»РЅРёС‚РµР»СЊРЅРѕРіРѕ РѕРєРЅР° РѕРїРёСЃР°РЅРёСЏ Р»РѕРєР°С†РёРё */
 const QSP_CHAR *QSPGetVarsDesc()
 {
 	return qspCurVars;
 }
-/* Возможность изменения текста дополнительного описания */
+/* Р’РѕР·РјРѕР¶РЅРѕСЃС‚СЊ РёР·РјРµРЅРµРЅРёСЏ С‚РµРєСЃС‚Р° РґРѕРїРѕР»РЅРёС‚РµР»СЊРЅРѕРіРѕ РѕРїРёСЃР°РЅРёСЏ */
 QSP_BOOL QSPIsVarsDescChanged()
 {
 	return qspIsVarsDescChanged;
 }
 /* ------------------------------------------------------------ */
-/* Получить значение указанного выражения */
+/* РџРѕР»СѓС‡РёС‚СЊ Р·РЅР°С‡РµРЅРёРµ СѓРєР°Р·Р°РЅРЅРѕРіРѕ РІС‹СЂР°Р¶РµРЅРёСЏ */
 QSP_BOOL QSPGetExprValue(const QSP_CHAR *expr, QSP_BOOL *isString, int *numVal, QSP_CHAR *strVal, int strValBufSize)
 {
 	QSPVariant v;
@@ -134,20 +134,20 @@ QSP_BOOL QSPGetExprValue(const QSP_CHAR *expr, QSP_BOOL *isString, int *numVal, 
 	return QSP_TRUE;
 }
 /* ------------------------------------------------------------ */
-/* Текст строки ввода */
+/* РўРµРєСЃС‚ СЃС‚СЂРѕРєРё РІРІРѕРґР° */
 void QSPSetInputStrText(const QSP_CHAR *val)
 {
 	qspCurInputLen = qspAddText(&qspCurInput, (QSP_CHAR *)val, 0, -1, QSP_FALSE);
 }
 /* ------------------------------------------------------------ */
-/* Список действий */
+/* РЎРїРёСЃРѕРє РґРµР№СЃС‚РІРёР№ */
 
-/* Количество действий */
+/* РљРѕР»РёС‡РµСЃС‚РІРѕ РґРµР№СЃС‚РІРёР№ */
 int QSPGetActionsCount()
 {
 	return qspCurActionsCount;
 }
-/* Данные действия с указанным индексом */
+/* Р”Р°РЅРЅС‹Рµ РґРµР№СЃС‚РІРёСЏ СЃ СѓРєР°Р·Р°РЅРЅС‹Рј РёРЅРґРµРєСЃРѕРј */
 void QSPGetActionData(int ind, QSP_CHAR **image, QSP_CHAR **desc)
 {
 	if (ind >= 0 && ind < qspCurActionsCount)
@@ -158,7 +158,7 @@ void QSPGetActionData(int ind, QSP_CHAR **image, QSP_CHAR **desc)
 	else
 		*image = *desc = 0;
 }
-/* Выполнение кода выбранного действия */
+/* Р’С‹РїРѕР»РЅРµРЅРёРµ РєРѕРґР° РІС‹Р±СЂР°РЅРЅРѕРіРѕ РґРµР№СЃС‚РІРёСЏ */
 QSP_BOOL QSPExecuteSelActionCode(QSP_BOOL isRefresh)
 {
 	if (qspCurSelAction >= 0)
@@ -172,7 +172,7 @@ QSP_BOOL QSPExecuteSelActionCode(QSP_BOOL isRefresh)
 	}
 	return QSP_TRUE;
 }
-/* Установить индекс выбранного действия */
+/* РЈСЃС‚Р°РЅРѕРІРёС‚СЊ РёРЅРґРµРєСЃ РІС‹Р±СЂР°РЅРЅРѕРіРѕ РґРµР№СЃС‚РІРёСЏ */
 QSP_BOOL QSPSetSelActionIndex(int ind, QSP_BOOL isRefresh)
 {
 	if (ind >= 0 && ind < qspCurActionsCount && ind != qspCurSelAction)
@@ -187,25 +187,25 @@ QSP_BOOL QSPSetSelActionIndex(int ind, QSP_BOOL isRefresh)
 	}
 	return QSP_TRUE;
 }
-/* Получить индекс выбранного действия */
+/* РџРѕР»СѓС‡РёС‚СЊ РёРЅРґРµРєСЃ РІС‹Р±СЂР°РЅРЅРѕРіРѕ РґРµР№СЃС‚РІРёСЏ */
 int QSPGetSelActionIndex()
 {
 	return qspCurSelAction;
 }
-/* Возможность изменения списка действий */
+/* Р’РѕР·РјРѕР¶РЅРѕСЃС‚СЊ РёР·РјРµРЅРµРЅРёСЏ СЃРїРёСЃРєР° РґРµР№СЃС‚РІРёР№ */
 QSP_BOOL QSPIsActionsChanged()
 {
 	return qspIsActionsChanged;
 }
 /* ------------------------------------------------------------ */
-/* Список объектов */
+/* РЎРїРёСЃРѕРє РѕР±СЉРµРєС‚РѕРІ */
 
-/* Количество объектов */
+/* РљРѕР»РёС‡РµСЃС‚РІРѕ РѕР±СЉРµРєС‚РѕРІ */
 int QSPGetObjectsCount()
 {
 	return qspCurObjectsCount;
 }
-/* Данные объекта с указанным индексом */
+/* Р”Р°РЅРЅС‹Рµ РѕР±СЉРµРєС‚Р° СЃ СѓРєР°Р·Р°РЅРЅС‹Рј РёРЅРґРµРєСЃРѕРј */
 void QSPGetObjectData(int ind, QSP_CHAR **image, QSP_CHAR **desc)
 {
 	if (ind >= 0 && ind < qspCurObjectsCount)
@@ -216,7 +216,7 @@ void QSPGetObjectData(int ind, QSP_CHAR **image, QSP_CHAR **desc)
 	else
 		*image = *desc = 0;
 }
-/* Установить индекс выбранного объекта */
+/* РЈСЃС‚Р°РЅРѕРІРёС‚СЊ РёРЅРґРµРєСЃ РІС‹Р±СЂР°РЅРЅРѕРіРѕ РѕР±СЉРµРєС‚Р° */
 QSP_BOOL QSPSetSelObjectIndex(int ind, QSP_BOOL isRefresh)
 {
 	if (ind >= 0 && ind < qspCurObjectsCount && ind != qspCurSelObject)
@@ -231,18 +231,18 @@ QSP_BOOL QSPSetSelObjectIndex(int ind, QSP_BOOL isRefresh)
 	}
 	return QSP_TRUE;
 }
-/* Получить индекс выбранного объекта */
+/* РџРѕР»СѓС‡РёС‚СЊ РёРЅРґРµРєСЃ РІС‹Р±СЂР°РЅРЅРѕРіРѕ РѕР±СЉРµРєС‚Р° */
 int QSPGetSelObjectIndex()
 {
 	return qspCurSelObject;
 }
-/* Возможность изменения списка объектов */
+/* Р’РѕР·РјРѕР¶РЅРѕСЃС‚СЊ РёР·РјРµРЅРµРЅРёСЏ СЃРїРёСЃРєР° РѕР±СЉРµРєС‚РѕРІ */
 QSP_BOOL QSPIsObjectsChanged()
 {
 	return qspIsObjectsChanged;
 }
 /* ------------------------------------------------------------ */
-/* Показ / скрытие окон */
+/* РџРѕРєР°Р· / СЃРєСЂС‹С‚РёРµ РѕРєРѕРЅ */
 void QSPShowWindow(int type, QSP_BOOL isShow)
 {
 	switch (type)
@@ -262,9 +262,9 @@ void QSPShowWindow(int type, QSP_BOOL isShow)
 	}
 }
 /* ------------------------------------------------------------ */
-/* Переменные */
+/* РџРµСЂРµРјРµРЅРЅС‹Рµ */
 
-/* Получить количество элементов массива */
+/* РџРѕР»СѓС‡РёС‚СЊ РєРѕР»РёС‡РµСЃС‚РІРѕ СЌР»РµРјРµРЅС‚РѕРІ РјР°СЃСЃРёРІР° */
 QSP_BOOL QSPGetVarValuesCount(const QSP_CHAR *name, int *count)
 {
 	QSPVar *var;
@@ -275,7 +275,7 @@ QSP_BOOL QSPGetVarValuesCount(const QSP_CHAR *name, int *count)
 	*count = var->ValsCount;
 	return QSP_TRUE;
 }
-/* Получить значения указанного элемента массива */
+/* РџРѕР»СѓС‡РёС‚СЊ Р·РЅР°С‡РµРЅРёСЏ СѓРєР°Р·Р°РЅРЅРѕРіРѕ СЌР»РµРјРµРЅС‚Р° РјР°СЃСЃРёРІР° */
 QSP_BOOL QSPGetVarValues(const QSP_CHAR *name, int ind, int *numVal, QSP_CHAR **strVal)
 {
 	QSPVar *var;
@@ -287,12 +287,12 @@ QSP_BOOL QSPGetVarValues(const QSP_CHAR *name, int ind, int *numVal, QSP_CHAR **
 	*strVal = var->Values[ind].Str;
 	return QSP_TRUE;
 }
-/* Получить максимальное количество переменных */
+/* РџРѕР»СѓС‡РёС‚СЊ РјР°РєСЃРёРјР°Р»СЊРЅРѕРµ РєРѕР»РёС‡РµСЃС‚РІРѕ РїРµСЂРµРјРµРЅРЅС‹С… */
 int QSPGetMaxVarsCount()
 {
 	return QSP_VARSCOUNT;
 }
-/* Получить имя переменной с указанным индексом */
+/* РџРѕР»СѓС‡РёС‚СЊ РёРјСЏ РїРµСЂРµРјРµРЅРЅРѕР№ СЃ СѓРєР°Р·Р°РЅРЅС‹Рј РёРЅРґРµРєСЃРѕРј */
 QSP_BOOL QSPGetVarNameByIndex(int index, QSP_CHAR **name)
 {
 	if (index < 0 || index >= QSP_VARSCOUNT || !qspVars[index].Name) return QSP_FALSE;
@@ -300,9 +300,9 @@ QSP_BOOL QSPGetVarNameByIndex(int index, QSP_CHAR **name)
 	return QSP_TRUE;
 }
 /* ------------------------------------------------------------ */
-/* Выполнение кода */
+/* Р’С‹РїРѕР»РЅРµРЅРёРµ РєРѕРґР° */
 
-/* Выполнение строки кода */
+/* Р’С‹РїРѕР»РЅРµРЅРёРµ СЃС‚СЂРѕРєРё РєРѕРґР° */
 QSP_BOOL QSPExecString(const QSP_CHAR *s, QSP_BOOL isRefresh)
 {
 	if (qspIsExitOnError && qspErrorNum) return QSP_FALSE;
@@ -313,7 +313,7 @@ QSP_BOOL QSPExecString(const QSP_CHAR *s, QSP_BOOL isRefresh)
 	if (isRefresh) qspCallRefreshInt(QSP_FALSE);
 	return QSP_TRUE;
 }
-/* Выполнение кода указанной локации */
+/* Р’С‹РїРѕР»РЅРµРЅРёРµ РєРѕРґР° СѓРєР°Р·Р°РЅРЅРѕР№ Р»РѕРєР°С†РёРё */
 QSP_BOOL QSPExecLocationCode(const QSP_CHAR *name, QSP_BOOL isRefresh)
 {
 	if (qspIsExitOnError && qspErrorNum) return QSP_FALSE;
@@ -324,7 +324,7 @@ QSP_BOOL QSPExecLocationCode(const QSP_CHAR *name, QSP_BOOL isRefresh)
 	if (isRefresh) qspCallRefreshInt(QSP_FALSE);
 	return QSP_TRUE;
 }
-/* Выполнение кода локации-счетчика */
+/* Р’С‹РїРѕР»РЅРµРЅРёРµ РєРѕРґР° Р»РѕРєР°С†РёРё-СЃС‡РµС‚С‡РёРєР° */
 QSP_BOOL QSPExecCounter(QSP_BOOL isRefresh)
 {
 	if (!qspIsInCallBack)
@@ -336,7 +336,7 @@ QSP_BOOL QSPExecCounter(QSP_BOOL isRefresh)
 	}
 	return QSP_TRUE;
 }
-/* Выполнение кода локации-обработчика строки ввода */
+/* Р’С‹РїРѕР»РЅРµРЅРёРµ РєРѕРґР° Р»РѕРєР°С†РёРё-РѕР±СЂР°Р±РѕС‚С‡РёРєР° СЃС‚СЂРѕРєРё РІРІРѕРґР° */
 QSP_BOOL QSPExecUserInput(QSP_BOOL isRefresh)
 {
 	if (qspIsExitOnError && qspErrorNum) return QSP_FALSE;
@@ -348,9 +348,9 @@ QSP_BOOL QSPExecUserInput(QSP_BOOL isRefresh)
 	return QSP_TRUE;
 }
 /* ------------------------------------------------------------ */
-/* Ошибки */
+/* РћС€РёР±РєРё */
 
-/* Получить информацию о последней ошибке */
+/* РџРѕР»СѓС‡РёС‚СЊ РёРЅС„РѕСЂРјР°С†РёСЋ Рѕ РїРѕСЃР»РµРґРЅРµР№ РѕС€РёР±РєРµ */
 void QSPGetLastErrorData(int *errorNum, QSP_CHAR **errorLoc, int *errorActIndex, int *errorLine)
 {
 	*errorNum = qspErrorNum;
@@ -358,15 +358,15 @@ void QSPGetLastErrorData(int *errorNum, QSP_CHAR **errorLoc, int *errorActIndex,
 	*errorActIndex = qspErrorActIndex;
 	*errorLine = qspErrorLine;
 }
-/* Получить описание ошибки по ее номеру */
+/* РџРѕР»СѓС‡РёС‚СЊ РѕРїРёСЃР°РЅРёРµ РѕС€РёР±РєРё РїРѕ РµРµ РЅРѕРјРµСЂСѓ */
 const QSP_CHAR *QSPGetErrorDesc(int errorNum)
 {
 	return qspGetErrorDesc(errorNum);
 }
 /* ------------------------------------------------------------ */
-/* Управление игрой */
+/* РЈРїСЂР°РІР»РµРЅРёРµ РёРіСЂРѕР№ */
 
-/* Загрузка новой игры из файла */
+/* Р—Р°РіСЂСѓР·РєР° РЅРѕРІРѕР№ РёРіСЂС‹ РёР· С„Р°Р№Р»Р° */
 QSP_BOOL QSPLoadGameWorld(const QSP_CHAR *fileName)
 {
 	if (qspIsExitOnError && qspErrorNum) return QSP_FALSE;
@@ -376,7 +376,7 @@ QSP_BOOL QSPLoadGameWorld(const QSP_CHAR *fileName)
 	if (qspErrorNum) return QSP_FALSE;
 	return QSP_TRUE;
 }
-/* Загрузка новой игры из памяти */
+/* Р—Р°РіСЂСѓР·РєР° РЅРѕРІРѕР№ РёРіСЂС‹ РёР· РїР°РјСЏС‚Рё */
 QSP_BOOL QSPLoadGameWorldFromData(const void *data, int dataSize, const QSP_CHAR *fileName)
 {
 	char *ptr;
@@ -391,7 +391,7 @@ QSP_BOOL QSPLoadGameWorldFromData(const void *data, int dataSize, const QSP_CHAR
 	if (qspErrorNum) return QSP_FALSE;
 	return QSP_TRUE;
 }
-/* Сохранение состояния в файл */
+/* РЎРѕС…СЂР°РЅРµРЅРёРµ СЃРѕСЃС‚РѕСЏРЅРёСЏ РІ С„Р°Р№Р» */
 QSP_BOOL QSPSaveGame(const QSP_CHAR *fileName, QSP_BOOL isRefresh)
 {
 	if (qspIsExitOnError && qspErrorNum) return QSP_FALSE;
@@ -402,7 +402,7 @@ QSP_BOOL QSPSaveGame(const QSP_CHAR *fileName, QSP_BOOL isRefresh)
 	if (isRefresh) qspCallRefreshInt(QSP_FALSE);
 	return QSP_TRUE;
 }
-/* Сохранение состояния в память */
+/* РЎРѕС…СЂР°РЅРµРЅРёРµ СЃРѕСЃС‚РѕСЏРЅРёСЏ РІ РїР°РјСЏС‚СЊ */
 QSP_BOOL QSPSaveGameAsData(void *buf, int bufSize, int *realSize, QSP_BOOL isRefresh)
 {
 	int len, size;
@@ -427,7 +427,7 @@ QSP_BOOL QSPSaveGameAsData(void *buf, int bufSize, int *realSize, QSP_BOOL isRef
 	if (isRefresh) qspCallRefreshInt(QSP_FALSE);
 	return QSP_TRUE;
 }
-/* Загрузка состояния из файла */
+/* Р—Р°РіСЂСѓР·РєР° СЃРѕСЃС‚РѕСЏРЅРёСЏ РёР· С„Р°Р№Р»Р° */
 QSP_BOOL QSPOpenSavedGame(const QSP_CHAR *fileName, QSP_BOOL isRefresh)
 {
 	if (qspIsExitOnError && qspErrorNum) return QSP_FALSE;
@@ -438,7 +438,7 @@ QSP_BOOL QSPOpenSavedGame(const QSP_CHAR *fileName, QSP_BOOL isRefresh)
 	if (isRefresh) qspCallRefreshInt(QSP_FALSE);
 	return QSP_TRUE;
 }
-/* Загрузка состояния из памяти */
+/* Р—Р°РіСЂСѓР·РєР° СЃРѕСЃС‚РѕСЏРЅРёСЏ РёР· РїР°РјСЏС‚Рё */
 QSP_BOOL QSPOpenSavedGameFromData(const void *data, int dataSize, QSP_BOOL isRefresh)
 {
 	int dataLen;
@@ -456,7 +456,7 @@ QSP_BOOL QSPOpenSavedGameFromData(const void *data, int dataSize, QSP_BOOL isRef
 	if (isRefresh) qspCallRefreshInt(QSP_FALSE);
 	return QSP_TRUE;
 }
-/* Перезапуск игры */
+/* РџРµСЂРµР·Р°РїСѓСЃРє РёРіСЂС‹ */
 QSP_BOOL QSPRestartGame(QSP_BOOL isRefresh)
 {
 	if (qspIsExitOnError && qspErrorNum) return QSP_FALSE;
@@ -468,13 +468,13 @@ QSP_BOOL QSPRestartGame(QSP_BOOL isRefresh)
 	return QSP_TRUE;
 }
 /* ------------------------------------------------------------ */
-/* Установка CALLBACK'ов */
+/* РЈСЃС‚Р°РЅРѕРІРєР° CALLBACK'РѕРІ */
 void QSPSetCallBack(int type, QSP_CALLBACK func)
 {
 	qspSetCallBack(type, func);
 }
 /* ------------------------------------------------------------ */
-/* Инициализация */
+/* РРЅРёС†РёР°Р»РёР·Р°С†РёСЏ */
 void QSPInit()
 {
 	#ifdef _DEBUG
@@ -503,7 +503,7 @@ void QSPInit()
 	qspInitStats();
 	qspInitMath();
 }
-/* Деинициализация */
+/* Р”РµРёРЅРёС†РёР°Р»РёР·Р°С†РёСЏ */
 void QSPDeInit()
 {
 	qspMemClear(QSP_FALSE);

--- a/qsp/bindings/default/default_callbacks.c
+++ b/qsp/bindings/default/default_callbacks.c
@@ -44,7 +44,7 @@ void qspSetCallBack(int type, QSP_CALLBACK func)
 
 void qspCallDebug(QSPString str)
 {
-	/* Здесь передаем управление отладчику */
+	/* Р—РґРµСЃСЊ РїРµСЂРµРґР°РµРј СѓРїСЂР°РІР»РµРЅРёРµ РѕС‚Р»Р°РґС‡РёРєСѓ */
 	QSPCallState state;
 	if (qspCallBacks[QSP_CALL_DEBUG])
 	{
@@ -56,7 +56,7 @@ void qspCallDebug(QSPString str)
 
 void qspCallSetTimer(int msecs)
 {
-	/* Здесь устанавливаем интервал таймера */
+	/* Р—РґРµСЃСЊ СѓСЃС‚Р°РЅР°РІР»РёРІР°РµРј РёРЅС‚РµСЂРІР°Р» С‚Р°Р№РјРµСЂР° */
 	QSPCallState state;
 	if (qspCallBacks[QSP_CALL_SETTIMER])
 	{
@@ -68,7 +68,7 @@ void qspCallSetTimer(int msecs)
 
 void qspCallRefreshInt(QSP_BOOL isRedraw)
 {
-	/* Здесь выполняем обновление интерфейса */
+	/* Р—РґРµСЃСЊ РІС‹РїРѕР»РЅСЏРµРј РѕР±РЅРѕРІР»РµРЅРёРµ РёРЅС‚РµСЂС„РµР№СЃР° */
 	QSPCallState state;
 	if (qspCallBacks[QSP_CALL_REFRESHINT])
 	{
@@ -80,7 +80,7 @@ void qspCallRefreshInt(QSP_BOOL isRedraw)
 
 void qspCallSetInputStrText(QSPString text)
 {
-	/* Здесь устанавливаем текст строки ввода */
+	/* Р—РґРµСЃСЊ СѓСЃС‚Р°РЅР°РІР»РёРІР°РµРј С‚РµРєСЃС‚ СЃС‚СЂРѕРєРё РІРІРѕРґР° */
 	QSPCallState state;
 	if (qspCallBacks[QSP_CALL_SETINPUTSTRTEXT])
 	{
@@ -92,7 +92,7 @@ void qspCallSetInputStrText(QSPString text)
 
 void qspCallSystem(QSPString cmd)
 {
-	/* Здесь выполняем системный вызов */
+	/* Р—РґРµСЃСЊ РІС‹РїРѕР»РЅСЏРµРј СЃРёСЃС‚РµРјРЅС‹Р№ РІС‹Р·РѕРІ */
 	QSPCallState state;
 	if (qspCallBacks[QSP_CALL_SYSTEM])
 	{
@@ -115,8 +115,8 @@ void qspCallOpenGame(QSPString file, QSP_BOOL isNewGame)
 
 void qspCallOpenGameStatus(QSPString file)
 {
-	/* Здесь позволяем пользователю выбрать файл */
-	/* состояния игры для загрузки и загружаем его */
+	/* Р—РґРµСЃСЊ РїРѕР·РІРѕР»СЏРµРј РїРѕР»СЊР·РѕРІР°С‚РµР»СЋ РІС‹Р±СЂР°С‚СЊ С„Р°Р№Р» */
+	/* СЃРѕСЃС‚РѕСЏРЅРёСЏ РёРіСЂС‹ РґР»СЏ Р·Р°РіСЂСѓР·РєРё Рё Р·Р°РіСЂСѓР¶Р°РµРј РµРіРѕ */
 	QSPCallState state;
 	if (qspCallBacks[QSP_CALL_OPENGAMESTATUS])
 	{
@@ -128,9 +128,9 @@ void qspCallOpenGameStatus(QSPString file)
 
 void qspCallSaveGameStatus(QSPString file)
 {
-	/* Здесь позволяем пользователю выбрать файл */
-	/* для сохранения состояния игры и сохраняем */
-	/* в нем текущее состояние */
+	/* Р—РґРµСЃСЊ РїРѕР·РІРѕР»СЏРµРј РїРѕР»СЊР·РѕРІР°С‚РµР»СЋ РІС‹Р±СЂР°С‚СЊ С„Р°Р№Р» */
+	/* РґР»СЏ СЃРѕС…СЂР°РЅРµРЅРёСЏ СЃРѕСЃС‚РѕСЏРЅРёСЏ РёРіСЂС‹ Рё СЃРѕС…СЂР°РЅСЏРµРј */
+	/* РІ РЅРµРј С‚РµРєСѓС‰РµРµ СЃРѕСЃС‚РѕСЏРЅРёРµ */
 	QSPCallState state;
 	if (qspCallBacks[QSP_CALL_SAVEGAMESTATUS])
 	{
@@ -142,7 +142,7 @@ void qspCallSaveGameStatus(QSPString file)
 
 void qspCallShowMessage(QSPString text)
 {
-	/* Здесь показываем сообщение */
+	/* Р—РґРµСЃСЊ РїРѕРєР°Р·С‹РІР°РµРј СЃРѕРѕР±С‰РµРЅРёРµ */
 	QSPCallState state;
 	if (qspCallBacks[QSP_CALL_SHOWMSGSTR])
 	{
@@ -154,7 +154,7 @@ void qspCallShowMessage(QSPString text)
 
 int qspCallShowMenu(QSPListItem *items, int count)
 {
-	/* Здесь показываем меню */
+	/* Р—РґРµСЃСЊ РїРѕРєР°Р·С‹РІР°РµРј РјРµРЅСЋ */
 	QSPCallState state;
 	int index;
 	if (qspCallBacks[QSP_CALL_SHOWMENU])
@@ -169,7 +169,7 @@ int qspCallShowMenu(QSPListItem *items, int count)
 
 void qspCallShowPicture(QSPString file)
 {
-	/* Здесь показываем изображение */
+	/* Р—РґРµСЃСЊ РїРѕРєР°Р·С‹РІР°РµРј РёР·РѕР±СЂР°Р¶РµРЅРёРµ */
 	QSPCallState state;
 	if (qspCallBacks[QSP_CALL_SHOWIMAGE])
 	{
@@ -181,7 +181,7 @@ void qspCallShowPicture(QSPString file)
 
 void qspCallShowWindow(int type, QSP_BOOL isShow)
 {
-	/* Здесь показываем или скрываем окно */
+	/* Р—РґРµСЃСЊ РїРѕРєР°Р·С‹РІР°РµРј РёР»Рё СЃРєСЂС‹РІР°РµРј РѕРєРЅРѕ */
 	QSPCallState state;
 	if (qspCallBacks[QSP_CALL_SHOWWINDOW])
 	{
@@ -193,7 +193,7 @@ void qspCallShowWindow(int type, QSP_BOOL isShow)
 
 void qspCallPlayFile(QSPString file, int volume)
 {
-	/* Здесь начинаем воспроизведение файла с заданной громкостью */
+	/* Р—РґРµСЃСЊ РЅР°С‡РёРЅР°РµРј РІРѕСЃРїСЂРѕРёР·РІРµРґРµРЅРёРµ С„Р°Р№Р»Р° СЃ Р·Р°РґР°РЅРЅРѕР№ РіСЂРѕРјРєРѕСЃС‚СЊСЋ */
 	QSPCallState state;
 	if (qspCallBacks[QSP_CALL_PLAYFILE])
 	{
@@ -205,7 +205,7 @@ void qspCallPlayFile(QSPString file, int volume)
 
 QSP_BOOL qspCallIsPlayingFile(QSPString file)
 {
-	/* Здесь проверяем, проигрывается ли файл */
+	/* Р—РґРµСЃСЊ РїСЂРѕРІРµСЂСЏРµРј, РїСЂРѕРёРіСЂС‹РІР°РµС‚СЃСЏ Р»Рё С„Р°Р№Р» */
 	QSPCallState state;
 	QSP_BOOL isPlaying;
 	if (qspCallBacks[QSP_CALL_ISPLAYINGFILE])
@@ -220,7 +220,7 @@ QSP_BOOL qspCallIsPlayingFile(QSPString file)
 
 void qspCallSleep(int msecs)
 {
-	/* Здесь ожидаем заданное количество миллисекунд */
+	/* Р—РґРµСЃСЊ РѕР¶РёРґР°РµРј Р·Р°РґР°РЅРЅРѕРµ РєРѕР»РёС‡РµСЃС‚РІРѕ РјРёР»Р»РёСЃРµРєСѓРЅРґ */
 	QSPCallState state;
 	if (qspCallBacks[QSP_CALL_SLEEP])
 	{
@@ -232,7 +232,7 @@ void qspCallSleep(int msecs)
 
 int qspCallGetMSCount()
 {
-	/* Здесь получаем количество миллисекунд, прошедших с момента последнего вызова функции */
+	/* Р—РґРµСЃСЊ РїРѕР»СѓС‡Р°РµРј РєРѕР»РёС‡РµСЃС‚РІРѕ РјРёР»Р»РёСЃРµРєСѓРЅРґ, РїСЂРѕС€РµРґС€РёС… СЃ РјРѕРјРµРЅС‚Р° РїРѕСЃР»РµРґРЅРµРіРѕ РІС‹Р·РѕРІР° С„СѓРЅРєС†РёРё */
 	QSPCallState state;
 	int count;
 	if (qspCallBacks[QSP_CALL_GETMSCOUNT])
@@ -247,7 +247,7 @@ int qspCallGetMSCount()
 
 void qspCallCloseFile(QSPString file)
 {
-	/* Здесь выполняем закрытие файла */
+	/* Р—РґРµСЃСЊ РІС‹РїРѕР»РЅСЏРµРј Р·Р°РєСЂС‹С‚РёРµ С„Р°Р№Р»Р° */
 	QSPCallState state;
 	if (qspCallBacks[QSP_CALL_CLOSEFILE])
 	{
@@ -259,7 +259,7 @@ void qspCallCloseFile(QSPString file)
 
 QSPString qspCallInputBox(QSPString text)
 {
-	/* Здесь вводим текст */
+	/* Р—РґРµСЃСЊ РІРІРѕРґРёРј С‚РµРєСЃС‚ */
 	QSPCallState state;
 	QSP_CHAR *buffer;
 	int maxLen = 511;

--- a/qsp/bindings/default/default_control.c
+++ b/qsp/bindings/default/default_control.c
@@ -69,14 +69,14 @@ static void qspSaveFileData(QSPString fileName, char *data, int dataSize)
 }
 
 /* ------------------------------------------------------------ */
-/* Отладка */
+/* РћС‚Р»Р°РґРєР° */
 
-/* Управление режимом отладки */
+/* РЈРїСЂР°РІР»РµРЅРёРµ СЂРµР¶РёРјРѕРј РѕС‚Р»Р°РґРєРё */
 void QSPEnableDebugMode(QSP_BOOL isDebug)
 {
 	qspIsDebug = isDebug;
 }
-/* Получение данных текущего состояния */
+/* РџРѕР»СѓС‡РµРЅРёРµ РґР°РЅРЅС‹С… С‚РµРєСѓС‰РµРіРѕ СЃРѕСЃС‚РѕСЏРЅРёСЏ */
 void QSPGetCurStateData(QSPString *loc, int *actIndex, int *line)
 {
 	*loc = (qspRealCurLoc >= 0 && qspRealCurLoc < qspLocsCount ? qspLocs[qspRealCurLoc].Name : qspNullString);
@@ -84,58 +84,58 @@ void QSPGetCurStateData(QSPString *loc, int *actIndex, int *line)
 	*line = qspRealLine;
 }
 /* ------------------------------------------------------------ */
-/* Информация о версии */
+/* РРЅС„РѕСЂРјР°С†РёСЏ Рѕ РІРµСЂСЃРёРё */
 
-/* Версия */
+/* Р’РµСЂСЃРёСЏ */
 QSPString QSPGetVersion()
 {
 	return QSP_STATIC_STR(QSP_VER);
 }
-/* Дата и время компиляции */
+/* Р”Р°С‚Р° Рё РІСЂРµРјСЏ РєРѕРјРїРёР»СЏС†РёРё */
 QSPString QSPGetCompiledDateTime()
 {
 	return QSP_STATIC_STR(QSP_FMT(__DATE__) QSP_FMT(", ") QSP_FMT(__TIME__));
 }
 /* ------------------------------------------------------------ */
-/* Количество полных обновлений локаций */
+/* РљРѕР»РёС‡РµСЃС‚РІРѕ РїРѕР»РЅС‹С… РѕР±РЅРѕРІР»РµРЅРёР№ Р»РѕРєР°С†РёР№ */
 int QSPGetFullRefreshCount()
 {
 	return qspFullRefreshCount;
 }
 /* ------------------------------------------------------------ */
-/* Основное описание локации */
+/* РћСЃРЅРѕРІРЅРѕРµ РѕРїРёСЃР°РЅРёРµ Р»РѕРєР°С†РёРё */
 
-/* Текст основного окна описания локации */
+/* РўРµРєСЃС‚ РѕСЃРЅРѕРІРЅРѕРіРѕ РѕРєРЅР° РѕРїРёСЃР°РЅРёСЏ Р»РѕРєР°С†РёРё */
 QSPString QSPGetMainDesc()
 {
 	return qspCurDesc;
 }
-/* Возможность изменения текста основного описания */
+/* Р’РѕР·РјРѕР¶РЅРѕСЃС‚СЊ РёР·РјРµРЅРµРЅРёСЏ С‚РµРєСЃС‚Р° РѕСЃРЅРѕРІРЅРѕРіРѕ РѕРїРёСЃР°РЅРёСЏ */
 QSP_BOOL QSPIsMainDescChanged()
 {
 	return qspIsMainDescChanged;
 }
 /* ------------------------------------------------------------ */
-/* Дополнительное описание локации */
+/* Р”РѕРїРѕР»РЅРёС‚РµР»СЊРЅРѕРµ РѕРїРёСЃР°РЅРёРµ Р»РѕРєР°С†РёРё */
 
-/* Текст дополнительного окна описания локации */
+/* РўРµРєСЃС‚ РґРѕРїРѕР»РЅРёС‚РµР»СЊРЅРѕРіРѕ РѕРєРЅР° РѕРїРёСЃР°РЅРёСЏ Р»РѕРєР°С†РёРё */
 QSPString QSPGetVarsDesc()
 {
 	return qspCurVars;
 }
-/* Возможность изменения текста дополнительного описания */
+/* Р’РѕР·РјРѕР¶РЅРѕСЃС‚СЊ РёР·РјРµРЅРµРЅРёСЏ С‚РµРєСЃС‚Р° РґРѕРїРѕР»РЅРёС‚РµР»СЊРЅРѕРіРѕ РѕРїРёСЃР°РЅРёСЏ */
 QSP_BOOL QSPIsVarsDescChanged()
 {
 	return qspIsVarsDescChanged;
 }
 /* ------------------------------------------------------------ */
-/* Текст строки ввода */
+/* РўРµРєСЃС‚ СЃС‚СЂРѕРєРё РІРІРѕРґР° */
 void QSPSetInputStrText(QSPString val)
 {
 	qspUpdateText(&qspCurInput, val);
 }
 /* ------------------------------------------------------------ */
-/* Список действий */
+/* РЎРїРёСЃРѕРє РґРµР№СЃС‚РІРёР№ */
 
 int QSPGetActions(QSPListItem *items, int itemsBufSize)
 {
@@ -147,7 +147,7 @@ int QSPGetActions(QSPListItem *items, int itemsBufSize)
 	}
 	return qspCurActionsCount;
 }
-/* Выполнение кода выбранного действия */
+/* Р’С‹РїРѕР»РЅРµРЅРёРµ РєРѕРґР° РІС‹Р±СЂР°РЅРЅРѕРіРѕ РґРµР№СЃС‚РІРёСЏ */
 QSP_BOOL QSPExecuteSelActionCode(QSP_BOOL isRefresh)
 {
 	if (qspCurSelAction >= 0)
@@ -161,7 +161,7 @@ QSP_BOOL QSPExecuteSelActionCode(QSP_BOOL isRefresh)
 	}
 	return QSP_TRUE;
 }
-/* Установить индекс выбранного действия */
+/* РЈСЃС‚Р°РЅРѕРІРёС‚СЊ РёРЅРґРµРєСЃ РІС‹Р±СЂР°РЅРЅРѕРіРѕ РґРµР№СЃС‚РІРёСЏ */
 QSP_BOOL QSPSetSelActionIndex(int ind, QSP_BOOL isRefresh)
 {
 	if (ind >= 0 && ind < qspCurActionsCount && ind != qspCurSelAction)
@@ -176,18 +176,18 @@ QSP_BOOL QSPSetSelActionIndex(int ind, QSP_BOOL isRefresh)
 	}
 	return QSP_TRUE;
 }
-/* Получить индекс выбранного действия */
+/* РџРѕР»СѓС‡РёС‚СЊ РёРЅРґРµРєСЃ РІС‹Р±СЂР°РЅРЅРѕРіРѕ РґРµР№СЃС‚РІРёСЏ */
 int QSPGetSelActionIndex()
 {
 	return qspCurSelAction;
 }
-/* Возможность изменения списка действий */
+/* Р’РѕР·РјРѕР¶РЅРѕСЃС‚СЊ РёР·РјРµРЅРµРЅРёСЏ СЃРїРёСЃРєР° РґРµР№СЃС‚РІРёР№ */
 QSP_BOOL QSPIsActionsChanged()
 {
 	return qspIsActionsChanged;
 }
 /* ------------------------------------------------------------ */
-/* Список объектов */
+/* РЎРїРёСЃРѕРє РѕР±СЉРµРєС‚РѕРІ */
 
 int QSPGetObjects(QSPListItem *items, int itemsBufSize)
 {
@@ -199,7 +199,7 @@ int QSPGetObjects(QSPListItem *items, int itemsBufSize)
 	}
 	return qspCurObjectsCount;
 }
-/* Установить индекс выбранного объекта */
+/* РЈСЃС‚Р°РЅРѕРІРёС‚СЊ РёРЅРґРµРєСЃ РІС‹Р±СЂР°РЅРЅРѕРіРѕ РѕР±СЉРµРєС‚Р° */
 QSP_BOOL QSPSetSelObjectIndex(int ind, QSP_BOOL isRefresh)
 {
 	if (ind >= 0 && ind < qspCurObjectsCount && ind != qspCurSelObject)
@@ -214,18 +214,18 @@ QSP_BOOL QSPSetSelObjectIndex(int ind, QSP_BOOL isRefresh)
 	}
 	return QSP_TRUE;
 }
-/* Получить индекс выбранного объекта */
+/* РџРѕР»СѓС‡РёС‚СЊ РёРЅРґРµРєСЃ РІС‹Р±СЂР°РЅРЅРѕРіРѕ РѕР±СЉРµРєС‚Р° */
 int QSPGetSelObjectIndex()
 {
 	return qspCurSelObject;
 }
-/* Возможность изменения списка объектов */
+/* Р’РѕР·РјРѕР¶РЅРѕСЃС‚СЊ РёР·РјРµРЅРµРЅРёСЏ СЃРїРёСЃРєР° РѕР±СЉРµРєС‚РѕРІ */
 QSP_BOOL QSPIsObjectsChanged()
 {
 	return qspIsObjectsChanged;
 }
 /* ------------------------------------------------------------ */
-/* Показ / скрытие окон */
+/* РџРѕРєР°Р· / СЃРєСЂС‹С‚РёРµ РѕРєРѕРЅ */
 void QSPShowWindow(int type, QSP_BOOL isShow)
 {
 	switch (type)
@@ -245,9 +245,9 @@ void QSPShowWindow(int type, QSP_BOOL isShow)
 	}
 }
 /* ------------------------------------------------------------ */
-/* Переменные */
+/* РџРµСЂРµРјРµРЅРЅС‹Рµ */
 
-/* Получить количество элементов массива */
+/* РџРѕР»СѓС‡РёС‚СЊ РєРѕР»РёС‡РµСЃС‚РІРѕ СЌР»РµРјРµРЅС‚РѕРІ РјР°СЃСЃРёРІР° */
 QSP_BOOL QSPGetVarValuesCount(QSPString name, int *count)
 {
 	QSPVar *var;
@@ -258,7 +258,7 @@ QSP_BOOL QSPGetVarValuesCount(QSPString name, int *count)
 	*count = var->ValsCount;
 	return QSP_TRUE;
 }
-/* Получить значения указанного элемента массива */
+/* РџРѕР»СѓС‡РёС‚СЊ Р·РЅР°С‡РµРЅРёСЏ СѓРєР°Р·Р°РЅРЅРѕРіРѕ СЌР»РµРјРµРЅС‚Р° РјР°СЃСЃРёРІР° */
 QSP_BOOL QSPGetVarValues(QSPString name, int ind, int *numVal, QSPString *strVal)
 {
 	QSPVar *var;
@@ -270,12 +270,12 @@ QSP_BOOL QSPGetVarValues(QSPString name, int ind, int *numVal, QSPString *strVal
 	*strVal = var->Values[ind].Str;
 	return QSP_TRUE;
 }
-/* Получить максимальное количество переменных */
+/* РџРѕР»СѓС‡РёС‚СЊ РјР°РєСЃРёРјР°Р»СЊРЅРѕРµ РєРѕР»РёС‡РµСЃС‚РІРѕ РїРµСЂРµРјРµРЅРЅС‹С… */
 int QSPGetMaxVarsCount()
 {
 	return QSP_VARSCOUNT;
 }
-/* Получить имя переменной с указанным индексом */
+/* РџРѕР»СѓС‡РёС‚СЊ РёРјСЏ РїРµСЂРµРјРµРЅРЅРѕР№ СЃ СѓРєР°Р·Р°РЅРЅС‹Рј РёРЅРґРµРєСЃРѕРј */
 QSP_BOOL QSPGetVarNameByIndex(int index, QSPString *name)
 {
 	if (index < 0 || index >= QSP_VARSCOUNT || !qspVars[index].Name.Str) return QSP_FALSE;
@@ -283,9 +283,9 @@ QSP_BOOL QSPGetVarNameByIndex(int index, QSPString *name)
 	return QSP_TRUE;
 }
 /* ------------------------------------------------------------ */
-/* Выполнение кода */
+/* Р’С‹РїРѕР»РЅРµРЅРёРµ РєРѕРґР° */
 
-/* Выполнение строки кода */
+/* Р’С‹РїРѕР»РЅРµРЅРёРµ СЃС‚СЂРѕРєРё РєРѕРґР° */
 QSP_BOOL QSPExecString(QSPString s, QSP_BOOL isRefresh)
 {
 	if (qspIsExitOnError && qspErrorNum) return QSP_FALSE;
@@ -296,7 +296,7 @@ QSP_BOOL QSPExecString(QSPString s, QSP_BOOL isRefresh)
 	if (isRefresh) qspCallRefreshInt(QSP_FALSE);
 	return QSP_TRUE;
 }
-/* Выполнение кода указанной локации */
+/* Р’С‹РїРѕР»РЅРµРЅРёРµ РєРѕРґР° СѓРєР°Р·Р°РЅРЅРѕР№ Р»РѕРєР°С†РёРё */
 QSP_BOOL QSPExecLocationCode(QSPString name, QSP_BOOL isRefresh)
 {
 	if (qspIsExitOnError && qspErrorNum) return QSP_FALSE;
@@ -307,7 +307,7 @@ QSP_BOOL QSPExecLocationCode(QSPString name, QSP_BOOL isRefresh)
 	if (isRefresh) qspCallRefreshInt(QSP_FALSE);
 	return QSP_TRUE;
 }
-/* Выполнение кода локации-счетчика */
+/* Р’С‹РїРѕР»РЅРµРЅРёРµ РєРѕРґР° Р»РѕРєР°С†РёРё-СЃС‡РµС‚С‡РёРєР° */
 QSP_BOOL QSPExecCounter(QSP_BOOL isRefresh)
 {
 	if (!qspIsInCallBack)
@@ -319,7 +319,7 @@ QSP_BOOL QSPExecCounter(QSP_BOOL isRefresh)
 	}
 	return QSP_TRUE;
 }
-/* Выполнение кода локации-обработчика строки ввода */
+/* Р’С‹РїРѕР»РЅРµРЅРёРµ РєРѕРґР° Р»РѕРєР°С†РёРё-РѕР±СЂР°Р±РѕС‚С‡РёРєР° СЃС‚СЂРѕРєРё РІРІРѕРґР° */
 QSP_BOOL QSPExecUserInput(QSP_BOOL isRefresh)
 {
 	if (qspIsExitOnError && qspErrorNum) return QSP_FALSE;
@@ -331,9 +331,9 @@ QSP_BOOL QSPExecUserInput(QSP_BOOL isRefresh)
 	return QSP_TRUE;
 }
 /* ------------------------------------------------------------ */
-/* Ошибки */
+/* РћС€РёР±РєРё */
 
-/* Получить информацию о последней ошибке */
+/* РџРѕР»СѓС‡РёС‚СЊ РёРЅС„РѕСЂРјР°С†РёСЋ Рѕ РїРѕСЃР»РµРґРЅРµР№ РѕС€РёР±РєРµ */
 void QSPGetLastErrorData(int *errorNum, QSPString *errorLoc, int *errorActIndex, int *errorLine)
 {
 	*errorNum = qspErrorNum;
@@ -341,15 +341,15 @@ void QSPGetLastErrorData(int *errorNum, QSPString *errorLoc, int *errorActIndex,
 	*errorActIndex = qspErrorActIndex;
 	*errorLine = qspErrorLine;
 }
-/* Получить описание ошибки по ее номеру */
+/* РџРѕР»СѓС‡РёС‚СЊ РѕРїРёСЃР°РЅРёРµ РѕС€РёР±РєРё РїРѕ РµРµ РЅРѕРјРµСЂСѓ */
 QSPString QSPGetErrorDesc(int errorNum)
 {
 	return qspGetErrorDesc(errorNum);
 }
 /* ------------------------------------------------------------ */
-/* Управление игрой */
+/* РЈРїСЂР°РІР»РµРЅРёРµ РёРіСЂРѕР№ */
 
-/* Загрузка новой игры из файла */
+/* Р—Р°РіСЂСѓР·РєР° РЅРѕРІРѕР№ РёРіСЂС‹ РёР· С„Р°Р№Р»Р° */
 QSP_BOOL QSPLoadGameWorld(QSPString fileName, QSP_BOOL isNewGame)
 {
 	char *buf;
@@ -366,7 +366,7 @@ QSP_BOOL QSPLoadGameWorld(QSPString fileName, QSP_BOOL isNewGame)
 	if (qspErrorNum) return QSP_FALSE;
 	return QSP_TRUE;
 }
-/* Сохранение состояния в файл */
+/* РЎРѕС…СЂР°РЅРµРЅРёРµ СЃРѕСЃС‚РѕСЏРЅРёСЏ РІ С„Р°Р№Р» */
 QSP_BOOL QSPSaveGame(QSPString fileName, QSP_BOOL isRefresh)
 {
 	QSPString data;
@@ -381,7 +381,7 @@ QSP_BOOL QSPSaveGame(QSPString fileName, QSP_BOOL isRefresh)
 	if (isRefresh) qspCallRefreshInt(QSP_FALSE);
 	return QSP_TRUE;
 }
-/* Загрузка состояния из файла */
+/* Р—Р°РіСЂСѓР·РєР° СЃРѕСЃС‚РѕСЏРЅРёСЏ РёР· С„Р°Р№Р»Р° */
 QSP_BOOL QSPOpenSavedGame(QSPString fileName, QSP_BOOL isRefresh)
 {
 	char *buf;
@@ -399,7 +399,7 @@ QSP_BOOL QSPOpenSavedGame(QSPString fileName, QSP_BOOL isRefresh)
 	if (isRefresh) qspCallRefreshInt(QSP_FALSE);
 	return QSP_TRUE;
 }
-/* Загрузка новой игры из памяти */
+/* Р—Р°РіСЂСѓР·РєР° РЅРѕРІРѕР№ РёРіСЂС‹ РёР· РїР°РјСЏС‚Рё */
 QSP_BOOL QSPLoadGameWorldFromData(const void *data, int dataSize, QSPString fileName, QSP_BOOL isNewGame)
 {
 	if (qspIsExitOnError && qspErrorNum) return QSP_FALSE;
@@ -409,7 +409,7 @@ QSP_BOOL QSPLoadGameWorldFromData(const void *data, int dataSize, QSPString file
 	if (qspErrorNum) return QSP_FALSE;
 	return QSP_TRUE;
 }
-/* Сохранение состояния в память */
+/* РЎРѕС…СЂР°РЅРµРЅРёРµ СЃРѕСЃС‚РѕСЏРЅРёСЏ РІ РїР°РјСЏС‚СЊ */
 QSP_BOOL QSPSaveGameAsData(void *buf, int bufSize, int *realSize, QSP_BOOL isRefresh)
 {
 	int size;
@@ -435,7 +435,7 @@ QSP_BOOL QSPSaveGameAsData(void *buf, int bufSize, int *realSize, QSP_BOOL isRef
 	if (isRefresh) qspCallRefreshInt(QSP_FALSE);
 	return QSP_TRUE;
 }
-/* Загрузка состояния из памяти */
+/* Р—Р°РіСЂСѓР·РєР° СЃРѕСЃС‚РѕСЏРЅРёСЏ РёР· РїР°РјСЏС‚Рё */
 QSP_BOOL QSPOpenSavedGameFromData(const void *data, int dataSize, QSP_BOOL isRefresh)
 {
 	if (qspIsExitOnError && qspErrorNum) return QSP_FALSE;
@@ -446,7 +446,7 @@ QSP_BOOL QSPOpenSavedGameFromData(const void *data, int dataSize, QSP_BOOL isRef
 	if (isRefresh) qspCallRefreshInt(QSP_FALSE);
 	return QSP_TRUE;
 }
-/* Перезапуск игры */
+/* РџРµСЂРµР·Р°РїСѓСЃРє РёРіСЂС‹ */
 QSP_BOOL QSPRestartGame(QSP_BOOL isRefresh)
 {
 	if (qspIsExitOnError && qspErrorNum) return QSP_FALSE;
@@ -458,13 +458,13 @@ QSP_BOOL QSPRestartGame(QSP_BOOL isRefresh)
 	return QSP_TRUE;
 }
 /* ------------------------------------------------------------ */
-/* Установка CALLBACK'ов */
+/* РЈСЃС‚Р°РЅРѕРІРєР° CALLBACK'РѕРІ */
 void QSPSetCallBack(int type, QSP_CALLBACK func)
 {
 	qspSetCallBack(type, func);
 }
 /* ------------------------------------------------------------ */
-/* Инициализация */
+/* РРЅРёС†РёР°Р»РёР·Р°С†РёСЏ */
 void QSPInit()
 {
 	#ifdef _DEBUG
@@ -494,7 +494,7 @@ void QSPInit()
 	qspInitStats();
 	qspInitMath();
 }
-/* Деинициализация */
+/* Р”РµРёРЅРёС†РёР°Р»РёР·Р°С†РёСЏ */
 void QSPDeInit()
 {
 	qspMemClear(QSP_FALSE);

--- a/qsp/bindings/flash/flash_callbacks.c
+++ b/qsp/bindings/flash/flash_callbacks.c
@@ -46,7 +46,7 @@ void qspSetCallBack(int type, QSP_CALLBACK func)
 
 void qspCallDebug(QSP_CHAR *str)
 {
-	/* Здесь передаем управление отладчику */
+	/* Р—РґРµСЃСЊ РїРµСЂРµРґР°РµРј СѓРїСЂР°РІР»РµРЅРёРµ РѕС‚Р»Р°РґС‡РёРєСѓ */
 	QSPCallState state;
 	char *strUTF8;
 	AS3_Val args;
@@ -70,7 +70,7 @@ void qspCallDebug(QSP_CHAR *str)
 
 void qspCallSetTimer(int msecs)
 {
-	/* Здесь устанавливаем интервал таймера */
+	/* Р—РґРµСЃСЊ СѓСЃС‚Р°РЅР°РІР»РёРІР°РµРј РёРЅС‚РµСЂРІР°Р» С‚Р°Р№РјРµСЂР° */
 	QSPCallState state;
 	AS3_Val args;
 	if (qspCallBacks[QSP_CALL_SETTIMER].IsSet)
@@ -86,7 +86,7 @@ void qspCallSetTimer(int msecs)
 
 void qspCallRefreshInt(QSP_BOOL isRedraw)
 {
-	/* Здесь выполняем обновление интерфейса */
+	/* Р—РґРµСЃСЊ РІС‹РїРѕР»РЅСЏРµРј РѕР±РЅРѕРІР»РµРЅРёРµ РёРЅС‚РµСЂС„РµР№СЃР° */
 	QSPCallState state;
 	AS3_Val args;
 	if (qspCallBacks[QSP_CALL_REFRESHINT].IsSet)
@@ -102,7 +102,7 @@ void qspCallRefreshInt(QSP_BOOL isRedraw)
 
 void qspCallSetInputStrText(QSP_CHAR *text)
 {
-	/* Здесь устанавливаем текст строки ввода */
+	/* Р—РґРµСЃСЊ СѓСЃС‚Р°РЅР°РІР»РёРІР°РµРј С‚РµРєСЃС‚ СЃС‚СЂРѕРєРё РІРІРѕРґР° */
 	QSPCallState state;
 	AS3_Val args;
 	char *textUTF8;
@@ -126,7 +126,7 @@ void qspCallSetInputStrText(QSP_CHAR *text)
 
 void qspCallAddMenuItem(QSP_CHAR *name, QSP_CHAR *imgPath)
 {
-	/* Здесь добавляем пункт меню */
+	/* Р—РґРµСЃСЊ РґРѕР±Р°РІР»СЏРµРј РїСѓРЅРєС‚ РјРµРЅСЋ */
 	QSPCallState state;
 	AS3_Val args;
 	char *nameUTF8;
@@ -148,7 +148,7 @@ void qspCallAddMenuItem(QSP_CHAR *name, QSP_CHAR *imgPath)
 
 void qspCallSystem(QSP_CHAR *cmd)
 {
-	/* Здесь выполняем системный вызов */
+	/* Р—РґРµСЃСЊ РІС‹РїРѕР»РЅСЏРµРј СЃРёСЃС‚РµРјРЅС‹Р№ РІС‹Р·РѕРІ */
 	QSPCallState state;
 	AS3_Val args;
 	char *strUTF8;
@@ -172,8 +172,8 @@ void qspCallSystem(QSP_CHAR *cmd)
 
 void qspCallOpenGameStatus(QSP_CHAR *file)
 {
-	/* Здесь позволяем пользователю выбрать файл */
-	/* состояния игры для загрузки и загружаем его */
+	/* Р—РґРµСЃСЊ РїРѕР·РІРѕР»СЏРµРј РїРѕР»СЊР·РѕРІР°С‚РµР»СЋ РІС‹Р±СЂР°С‚СЊ С„Р°Р№Р» */
+	/* СЃРѕСЃС‚РѕСЏРЅРёСЏ РёРіСЂС‹ РґР»СЏ Р·Р°РіСЂСѓР·РєРё Рё Р·Р°РіСЂСѓР¶Р°РµРј РµРіРѕ */
 	QSPCallState state;
 	AS3_Val args;
 	char *strUTF8;
@@ -197,9 +197,9 @@ void qspCallOpenGameStatus(QSP_CHAR *file)
 
 void qspCallSaveGameStatus(QSP_CHAR *file)
 {
-	/* Здесь позволяем пользователю выбрать файл */
-	/* для сохранения состояния игры и сохраняем */
-	/* в нем текущее состояние */
+	/* Р—РґРµСЃСЊ РїРѕР·РІРѕР»СЏРµРј РїРѕР»СЊР·РѕРІР°С‚РµР»СЋ РІС‹Р±СЂР°С‚СЊ С„Р°Р№Р» */
+	/* РґР»СЏ СЃРѕС…СЂР°РЅРµРЅРёСЏ СЃРѕСЃС‚РѕСЏРЅРёСЏ РёРіСЂС‹ Рё СЃРѕС…СЂР°РЅСЏРµРј */
+	/* РІ РЅРµРј С‚РµРєСѓС‰РµРµ СЃРѕСЃС‚РѕСЏРЅРёРµ */
 	QSPCallState state;
 	AS3_Val args;
 	char *strUTF8;
@@ -223,7 +223,7 @@ void qspCallSaveGameStatus(QSP_CHAR *file)
 
 void qspCallShowMessage(QSP_CHAR *text)
 {
-	/* Здесь показываем сообщение */
+	/* Р—РґРµСЃСЊ РїРѕРєР°Р·С‹РІР°РµРј СЃРѕРѕР±С‰РµРЅРёРµ */
 	QSPCallState state;
 	AS3_Val args;
 	char *strUTF8;
@@ -247,7 +247,7 @@ void qspCallShowMessage(QSP_CHAR *text)
 
 int qspCallShowMenu()
 {
-	/* Здесь показываем меню */
+	/* Р—РґРµСЃСЊ РїРѕРєР°Р·С‹РІР°РµРј РјРµРЅСЋ */
 	QSPCallState state;
 	int index;
 	AS3_Val args;
@@ -268,7 +268,7 @@ int qspCallShowMenu()
 
 void qspCallShowPicture(QSP_CHAR *file)
 {
-	/* Здесь показываем изображение */
+	/* Р—РґРµСЃСЊ РїРѕРєР°Р·С‹РІР°РµРј РёР·РѕР±СЂР°Р¶РµРЅРёРµ */
 	QSPCallState state;
 	AS3_Val args;
 	char *strUTF8;
@@ -292,7 +292,7 @@ void qspCallShowPicture(QSP_CHAR *file)
 
 void qspCallShowWindow(int type, QSP_BOOL isShow)
 {
-	/* Здесь показываем или скрываем окно */
+	/* Р—РґРµСЃСЊ РїРѕРєР°Р·С‹РІР°РµРј РёР»Рё СЃРєСЂС‹РІР°РµРј РѕРєРЅРѕ */
 	QSPCallState state;
 	AS3_Val args;
 	if (qspCallBacks[QSP_CALL_SHOWWINDOW].IsSet)
@@ -308,7 +308,7 @@ void qspCallShowWindow(int type, QSP_BOOL isShow)
 
 void qspCallPlayFile(QSP_CHAR *file, int volume)
 {
-	/* Здесь начинаем воспроизведение файла с заданной громкостью */
+	/* Р—РґРµСЃСЊ РЅР°С‡РёРЅР°РµРј РІРѕСЃРїСЂРѕРёР·РІРµРґРµРЅРёРµ С„Р°Р№Р»Р° СЃ Р·Р°РґР°РЅРЅРѕР№ РіСЂРѕРјРєРѕСЃС‚СЊСЋ */
 	QSPCallState state;
 	AS3_Val args;
 	char *strUTF8;
@@ -332,7 +332,7 @@ void qspCallPlayFile(QSP_CHAR *file, int volume)
 
 QSP_BOOL qspCallIsPlayingFile(QSP_CHAR *file)
 {
-	/* Здесь проверяем, проигрывается ли файл */
+	/* Р—РґРµСЃСЊ РїСЂРѕРІРµСЂСЏРµРј, РїСЂРѕРёРіСЂС‹РІР°РµС‚СЃСЏ Р»Рё С„Р°Р№Р» */
 	QSPCallState state;
 	QSP_BOOL isPlaying;
 	AS3_Val args;
@@ -361,7 +361,7 @@ QSP_BOOL qspCallIsPlayingFile(QSP_CHAR *file)
 
 void qspCallSleep(int msecs)
 {
-	/* Здесь ожидаем заданное количество миллисекунд */
+	/* Р—РґРµСЃСЊ РѕР¶РёРґР°РµРј Р·Р°РґР°РЅРЅРѕРµ РєРѕР»РёС‡РµСЃС‚РІРѕ РјРёР»Р»РёСЃРµРєСѓРЅРґ */
 	QSPCallState state;
 	AS3_Val args;
 	if (qspCallBacks[QSP_CALL_SLEEP].IsSet)
@@ -377,7 +377,7 @@ void qspCallSleep(int msecs)
 
 int qspCallGetMSCount()
 {
-	/* Здесь получаем количество миллисекунд, прошедших с момента последнего вызова функции */
+	/* Р—РґРµСЃСЊ РїРѕР»СѓС‡Р°РµРј РєРѕР»РёС‡РµСЃС‚РІРѕ РјРёР»Р»РёСЃРµРєСѓРЅРґ, РїСЂРѕС€РµРґС€РёС… СЃ РјРѕРјРµРЅС‚Р° РїРѕСЃР»РµРґРЅРµРіРѕ РІС‹Р·РѕРІР° С„СѓРЅРєС†РёРё */
 	QSPCallState state;
 	int count;
 	AS3_Val args;
@@ -398,7 +398,7 @@ int qspCallGetMSCount()
 
 void qspCallCloseFile(QSP_CHAR *file)
 {
-	/* Здесь выполняем закрытие файла */
+	/* Р—РґРµСЃСЊ РІС‹РїРѕР»РЅСЏРµРј Р·Р°РєСЂС‹С‚РёРµ С„Р°Р№Р»Р° */
 	QSPCallState state;
 	AS3_Val args;
 	char *strUTF8;
@@ -422,7 +422,7 @@ void qspCallCloseFile(QSP_CHAR *file)
 
 void qspCallDeleteMenu()
 {
-	/* Здесь удаляем текущее меню */
+	/* Р—РґРµСЃСЊ СѓРґР°Р»СЏРµРј С‚РµРєСѓС‰РµРµ РјРµРЅСЋ */
 	QSPCallState state;
 	AS3_Val args;
 	if (qspCallBacks[QSP_CALL_DELETEMENU].IsSet)
@@ -438,7 +438,7 @@ void qspCallDeleteMenu()
 
 QSPString qspCallInputBox(QSPString text)
 {
-	/* Здесь вводим текст */
+	/* Р—РґРµСЃСЊ РІРІРѕРґРёРј С‚РµРєСЃС‚ */
 	QSPCallState state;
 	QSP_CHAR *buffer;
 	AS3_Val args;

--- a/qsp/bindings/flash/flash_control.c
+++ b/qsp/bindings/flash/flash_control.c
@@ -44,7 +44,7 @@ AS3_Val QSPIsInCallBack(void *param, AS3_Val args)
 		return AS3_False();
 }
 /* ------------------------------------------------------------ */
-/* Управление режимом отладки */
+/* РЈРїСЂР°РІР»РµРЅРёРµ СЂРµР¶РёРјРѕРј РѕС‚Р»Р°РґРєРё */
 AS3_Val QSPEnableDebugMode(void *param, AS3_Val args)
 {
 	QSP_BOOL isDebug;
@@ -52,7 +52,7 @@ AS3_Val QSPEnableDebugMode(void *param, AS3_Val args)
 	qspIsDebug = isDebug;
 	return AS3_True();
 }
-/* Получение данных текущего состояния */
+/* РџРѕР»СѓС‡РµРЅРёРµ РґР°РЅРЅС‹С… С‚РµРєСѓС‰РµРіРѕ СЃРѕСЃС‚РѕСЏРЅРёСЏ */
 AS3_Val QSPGetCurStateData(void *param, AS3_Val args)
 {
 	char *locUTF8;
@@ -68,9 +68,9 @@ AS3_Val QSPGetCurStateData(void *param, AS3_Val args)
 	return res;
 }
 /* ------------------------------------------------------------ */
-/* Информация о версии */
+/* РРЅС„РѕСЂРјР°С†РёСЏ Рѕ РІРµСЂСЃРёРё */
 
-/* Версия */
+/* Р’РµСЂСЃРёСЏ */
 AS3_Val QSPGetVersion(void *param, AS3_Val args)
 {
 	AS3_Val res;
@@ -79,7 +79,7 @@ AS3_Val QSPGetVersion(void *param, AS3_Val args)
 	free(verUTF8);
 	return res;
 }
-/* Дата и время компиляции */
+/* Р”Р°С‚Р° Рё РІСЂРµРјСЏ РєРѕРјРїРёР»СЏС†РёРё */
 AS3_Val QSPGetCompiledDateTime(void *param, AS3_Val args)
 {
 	AS3_Val res;
@@ -89,13 +89,13 @@ AS3_Val QSPGetCompiledDateTime(void *param, AS3_Val args)
 	return res;
 }
 /* ------------------------------------------------------------ */
-/* Количество полных обновлений локаций */
+/* РљРѕР»РёС‡РµСЃС‚РІРѕ РїРѕР»РЅС‹С… РѕР±РЅРѕРІР»РµРЅРёР№ Р»РѕРєР°С†РёР№ */
 AS3_Val QSPGetFullRefreshCount(void *param, AS3_Val args)
 {
 	return AS3_Int(qspFullRefreshCount);
 }
 /* ------------------------------------------------------------ */
-/* Полный путь к загруженному файлу игры */
+/* РџРѕР»РЅС‹Р№ РїСѓС‚СЊ Рє Р·Р°РіСЂСѓР¶РµРЅРЅРѕРјСѓ С„Р°Р№Р»Сѓ РёРіСЂС‹ */
 AS3_Val QSPGetQstFullPath(void *param, AS3_Val args)
 {
 	AS3_Val res;
@@ -111,7 +111,7 @@ AS3_Val QSPGetQstFullPath(void *param, AS3_Val args)
 	return res;
 }
 /* ------------------------------------------------------------ */
-/* Название текущей локации */
+/* РќР°Р·РІР°РЅРёРµ С‚РµРєСѓС‰РµР№ Р»РѕРєР°С†РёРё */
 AS3_Val QSPGetCurLoc(void *param, AS3_Val args)
 {
 	AS3_Val res;
@@ -127,9 +127,9 @@ AS3_Val QSPGetCurLoc(void *param, AS3_Val args)
 	return res;
 }
 /* ------------------------------------------------------------ */
-/* Основное описание локации */
+/* РћСЃРЅРѕРІРЅРѕРµ РѕРїРёСЃР°РЅРёРµ Р»РѕРєР°С†РёРё */
 
-/* Текст основного окна описания локации */
+/* РўРµРєСЃС‚ РѕСЃРЅРѕРІРЅРѕРіРѕ РѕРєРЅР° РѕРїРёСЃР°РЅРёСЏ Р»РѕРєР°С†РёРё */
 AS3_Val QSPGetMainDesc(void *param, AS3_Val args)
 {
 	AS3_Val res;
@@ -144,7 +144,7 @@ AS3_Val QSPGetMainDesc(void *param, AS3_Val args)
 		res = AS3_String(0);
 	return res;
 }
-/* Возможность изменения текста основного описания */
+/* Р’РѕР·РјРѕР¶РЅРѕСЃС‚СЊ РёР·РјРµРЅРµРЅРёСЏ С‚РµРєСЃС‚Р° РѕСЃРЅРѕРІРЅРѕРіРѕ РѕРїРёСЃР°РЅРёСЏ */
 AS3_Val QSPIsMainDescChanged(void *param, AS3_Val args)
 {
 	if (qspIsMainDescChanged)
@@ -153,9 +153,9 @@ AS3_Val QSPIsMainDescChanged(void *param, AS3_Val args)
 		return AS3_False();
 }
 /* ------------------------------------------------------------ */
-/* Дополнительное описание локации */
+/* Р”РѕРїРѕР»РЅРёС‚РµР»СЊРЅРѕРµ РѕРїРёСЃР°РЅРёРµ Р»РѕРєР°С†РёРё */
 
-/* Текст дополнительного окна описания локации */
+/* РўРµРєСЃС‚ РґРѕРїРѕР»РЅРёС‚РµР»СЊРЅРѕРіРѕ РѕРєРЅР° РѕРїРёСЃР°РЅРёСЏ Р»РѕРєР°С†РёРё */
 AS3_Val QSPGetVarsDesc(void *param, AS3_Val args)
 {
 	AS3_Val res;
@@ -170,7 +170,7 @@ AS3_Val QSPGetVarsDesc(void *param, AS3_Val args)
 		res = AS3_String(0);
 	return res;
 }
-/* Возможность изменения текста дополнительного описания */
+/* Р’РѕР·РјРѕР¶РЅРѕСЃС‚СЊ РёР·РјРµРЅРµРЅРёСЏ С‚РµРєСЃС‚Р° РґРѕРїРѕР»РЅРёС‚РµР»СЊРЅРѕРіРѕ РѕРїРёСЃР°РЅРёСЏ */
 AS3_Val QSPIsVarsDescChanged(void *param, AS3_Val args)
 {
 	if (qspIsVarsDescChanged)
@@ -179,7 +179,7 @@ AS3_Val QSPIsVarsDescChanged(void *param, AS3_Val args)
 		return AS3_False();
 }
 /* ------------------------------------------------------------ */
-/* Получить значение указанного выражения */
+/* РџРѕР»СѓС‡РёС‚СЊ Р·РЅР°С‡РµРЅРёРµ СѓРєР°Р·Р°РЅРЅРѕРіРѕ РІС‹СЂР°Р¶РµРЅРёСЏ */
 AS3_Val QSPGetExprValue(void *param, AS3_Val args)
 {
 	char *expr;
@@ -207,7 +207,7 @@ AS3_Val QSPGetExprValue(void *param, AS3_Val args)
 	return res;
 }
 /* ------------------------------------------------------------ */
-/* Текст строки ввода */
+/* РўРµРєСЃС‚ СЃС‚СЂРѕРєРё РІРІРѕРґР° */
 AS3_Val QSPSetInputStrText(void *param, AS3_Val args)
 {
 	QSP_CHAR *valWC;
@@ -219,14 +219,14 @@ AS3_Val QSPSetInputStrText(void *param, AS3_Val args)
 	return AS3_True();
 }
 /* ------------------------------------------------------------ */
-/* Список действий */
+/* РЎРїРёСЃРѕРє РґРµР№СЃС‚РІРёР№ */
 
-/* Количество действий */
+/* РљРѕР»РёС‡РµСЃС‚РІРѕ РґРµР№СЃС‚РІРёР№ */
 AS3_Val QSPGetActionsCount(void *param, AS3_Val args)
 {
 	return AS3_Int(qspCurActionsCount);
 }
-/* Данные действия с указанным индексом */
+/* Р”Р°РЅРЅС‹Рµ РґРµР№СЃС‚РІРёСЏ СЃ СѓРєР°Р·Р°РЅРЅС‹Рј РёРЅРґРµРєСЃРѕРј */
 AS3_Val QSPGetActionData(void *param, AS3_Val args)
 {
 	int ind;
@@ -246,7 +246,7 @@ AS3_Val QSPGetActionData(void *param, AS3_Val args)
 		res = AS3_Object("image:StrType, desc:StrType", 0, 0);
 	return res;
 }
-/* Выполнение кода выбранного действия */
+/* Р’С‹РїРѕР»РЅРµРЅРёРµ РєРѕРґР° РІС‹Р±СЂР°РЅРЅРѕРіРѕ РґРµР№СЃС‚РІРёСЏ */
 AS3_Val QSPExecuteSelActionCode(void *param, AS3_Val args)
 {
 	QSP_BOOL isRefresh;
@@ -262,7 +262,7 @@ AS3_Val QSPExecuteSelActionCode(void *param, AS3_Val args)
 	}
 	return AS3_True();
 }
-/* Установить индекс выбранного действия */
+/* РЈСЃС‚Р°РЅРѕРІРёС‚СЊ РёРЅРґРµРєСЃ РІС‹Р±СЂР°РЅРЅРѕРіРѕ РґРµР№СЃС‚РІРёСЏ */
 AS3_Val QSPSetSelActionIndex(void *param, AS3_Val args)
 {
 	int ind;
@@ -280,12 +280,12 @@ AS3_Val QSPSetSelActionIndex(void *param, AS3_Val args)
 	}
 	return AS3_True();
 }
-/* Получить индекс выбранного действия */
+/* РџРѕР»СѓС‡РёС‚СЊ РёРЅРґРµРєСЃ РІС‹Р±СЂР°РЅРЅРѕРіРѕ РґРµР№СЃС‚РІРёСЏ */
 AS3_Val QSPGetSelActionIndex(void *param, AS3_Val args)
 {
 	return AS3_Int(qspCurSelAction);
 }
-/* Возможность изменения списка действий */
+/* Р’РѕР·РјРѕР¶РЅРѕСЃС‚СЊ РёР·РјРµРЅРµРЅРёСЏ СЃРїРёСЃРєР° РґРµР№СЃС‚РІРёР№ */
 AS3_Val QSPIsActionsChanged(void *param, AS3_Val args)
 {
 	if (qspIsActionsChanged)
@@ -294,14 +294,14 @@ AS3_Val QSPIsActionsChanged(void *param, AS3_Val args)
 		return AS3_False();
 }
 /* ------------------------------------------------------------ */
-/* Список объектов */
+/* РЎРїРёСЃРѕРє РѕР±СЉРµРєС‚РѕРІ */
 
-/* Количество объектов */
+/* РљРѕР»РёС‡РµСЃС‚РІРѕ РѕР±СЉРµРєС‚РѕРІ */
 AS3_Val QSPGetObjectsCount(void *param, AS3_Val args)
 {
 	return AS3_Int(qspCurObjectsCount);
 }
-/* Данные объекта с указанным индексом */
+/* Р”Р°РЅРЅС‹Рµ РѕР±СЉРµРєС‚Р° СЃ СѓРєР°Р·Р°РЅРЅС‹Рј РёРЅРґРµРєСЃРѕРј */
 AS3_Val QSPGetObjectData(void *param, AS3_Val args)
 {
 	int ind;
@@ -321,7 +321,7 @@ AS3_Val QSPGetObjectData(void *param, AS3_Val args)
 		res = AS3_Object("image:StrType, desc:StrType", 0, 0);
 	return res;
 }
-/* Установить индекс выбранного объекта */
+/* РЈСЃС‚Р°РЅРѕРІРёС‚СЊ РёРЅРґРµРєСЃ РІС‹Р±СЂР°РЅРЅРѕРіРѕ РѕР±СЉРµРєС‚Р° */
 AS3_Val QSPSetSelObjectIndex(void *param, AS3_Val args)
 {
 	int ind;
@@ -339,12 +339,12 @@ AS3_Val QSPSetSelObjectIndex(void *param, AS3_Val args)
 	}
 	return AS3_True();
 }
-/* Получить индекс выбранного объекта */
+/* РџРѕР»СѓС‡РёС‚СЊ РёРЅРґРµРєСЃ РІС‹Р±СЂР°РЅРЅРѕРіРѕ РѕР±СЉРµРєС‚Р° */
 AS3_Val QSPGetSelObjectIndex(void *param, AS3_Val args)
 {
 	return AS3_Int(qspCurSelObject);
 }
-/* Возможность изменения списка объектов */
+/* Р’РѕР·РјРѕР¶РЅРѕСЃС‚СЊ РёР·РјРµРЅРµРЅРёСЏ СЃРїРёСЃРєР° РѕР±СЉРµРєС‚РѕРІ */
 AS3_Val QSPIsObjectsChanged(void *param, AS3_Val args)
 {
 	if (qspIsObjectsChanged)
@@ -353,7 +353,7 @@ AS3_Val QSPIsObjectsChanged(void *param, AS3_Val args)
 		return AS3_False();
 }
 /* ------------------------------------------------------------ */
-/* Показ / скрытие окон */
+/* РџРѕРєР°Р· / СЃРєСЂС‹С‚РёРµ РѕРєРѕРЅ */
 AS3_Val QSPShowWindow(void *param, AS3_Val args)
 {
 	int type;
@@ -377,9 +377,9 @@ AS3_Val QSPShowWindow(void *param, AS3_Val args)
 	return AS3_True();
 }
 /* ------------------------------------------------------------ */
-/* Переменные */
+/* РџРµСЂРµРјРµРЅРЅС‹Рµ */
 
-/* Получить количество элементов массива */
+/* РџРѕР»СѓС‡РёС‚СЊ РєРѕР»РёС‡РµСЃС‚РІРѕ СЌР»РµРјРµРЅС‚РѕРІ РјР°СЃСЃРёРІР° */
 AS3_Val QSPGetVarValuesCount(void *param, AS3_Val args)
 {
 	char *name;
@@ -394,7 +394,7 @@ AS3_Val QSPGetVarValuesCount(void *param, AS3_Val args)
 	if (qspErrorNum) return AS3_Null();
 	return AS3_Int(var->ValsCount);
 }
-/* Получить значения указанного элемента массива */
+/* РџРѕР»СѓС‡РёС‚СЊ Р·РЅР°С‡РµРЅРёСЏ СѓРєР°Р·Р°РЅРЅРѕРіРѕ СЌР»РµРјРµРЅС‚Р° РјР°СЃСЃРёРІР° */
 AS3_Val QSPGetVarValues(void *param, AS3_Val args)
 {
 	char *name;
@@ -420,12 +420,12 @@ AS3_Val QSPGetVarValues(void *param, AS3_Val args)
 		res = AS3_Object("numVal:IntType, strVal:StrType", var->Values[ind].Num, 0);
 	return res;
 }
-/* Получить максимальное количество переменных */
+/* РџРѕР»СѓС‡РёС‚СЊ РјР°РєСЃРёРјР°Р»СЊРЅРѕРµ РєРѕР»РёС‡РµСЃС‚РІРѕ РїРµСЂРµРјРµРЅРЅС‹С… */
 AS3_Val QSPGetMaxVarsCount(void *param, AS3_Val args)
 {
 	return AS3_Int(QSP_VARSCOUNT);
 }
-/* Получить имя переменной с указанным индексом */
+/* РџРѕР»СѓС‡РёС‚СЊ РёРјСЏ РїРµСЂРµРјРµРЅРЅРѕР№ СЃ СѓРєР°Р·Р°РЅРЅС‹Рј РёРЅРґРµРєСЃРѕРј */
 AS3_Val QSPGetVarNameByIndex(void *param, AS3_Val args)
 {
 	int index;
@@ -440,9 +440,9 @@ AS3_Val QSPGetVarNameByIndex(void *param, AS3_Val args)
 	return res;
 }
 /* ------------------------------------------------------------ */
-/* Выполнение кода */
+/* Р’С‹РїРѕР»РЅРµРЅРёРµ РєРѕРґР° */
 
-/* Выполнение строки кода */
+/* Р’С‹РїРѕР»РЅРµРЅРёРµ СЃС‚СЂРѕРєРё РєРѕРґР° */
 AS3_Val QSPExecString(void *param, AS3_Val args)
 {
 	char *s;
@@ -459,7 +459,7 @@ AS3_Val QSPExecString(void *param, AS3_Val args)
 	if (isRefresh) qspCallRefreshInt(QSP_FALSE);
 	return AS3_True();
 }
-/* Выполнение кода указанной локации */
+/* Р’С‹РїРѕР»РЅРµРЅРёРµ РєРѕРґР° СѓРєР°Р·Р°РЅРЅРѕР№ Р»РѕРєР°С†РёРё */
 AS3_Val QSPExecLocationCode(void *param, AS3_Val args)
 {
 	char *name;
@@ -476,7 +476,7 @@ AS3_Val QSPExecLocationCode(void *param, AS3_Val args)
 	if (isRefresh) qspCallRefreshInt(QSP_FALSE);
 	return AS3_True();
 }
-/* Выполнение кода локации-счетчика */
+/* Р’С‹РїРѕР»РЅРµРЅРёРµ РєРѕРґР° Р»РѕРєР°С†РёРё-СЃС‡РµС‚С‡РёРєР° */
 AS3_Val QSPExecCounter(void *param, AS3_Val args)
 {
 	QSP_BOOL isRefresh;
@@ -490,7 +490,7 @@ AS3_Val QSPExecCounter(void *param, AS3_Val args)
 	}
 	return AS3_True();
 }
-/* Выполнение кода локации-обработчика строки ввода */
+/* Р’С‹РїРѕР»РЅРµРЅРёРµ РєРѕРґР° Р»РѕРєР°С†РёРё-РѕР±СЂР°Р±РѕС‚С‡РёРєР° СЃС‚СЂРѕРєРё РІРІРѕРґР° */
 AS3_Val QSPExecUserInput(void *param, AS3_Val args)
 {
 	QSP_BOOL isRefresh;
@@ -504,9 +504,9 @@ AS3_Val QSPExecUserInput(void *param, AS3_Val args)
 	return AS3_True();
 }
 /* ------------------------------------------------------------ */
-/* Ошибки */
+/* РћС€РёР±РєРё */
 
-/* Получить информацию о последней ошибке */
+/* РџРѕР»СѓС‡РёС‚СЊ РёРЅС„РѕСЂРјР°С†РёСЋ Рѕ РїРѕСЃР»РµРґРЅРµР№ РѕС€РёР±РєРµ */
 AS3_Val QSPGetLastErrorData(void *param, AS3_Val args)
 {
 	AS3_Val res;
@@ -525,7 +525,7 @@ AS3_Val QSPGetLastErrorData(void *param, AS3_Val args)
 	}
 	return res;
 }
-/* Получить описание ошибки по ее номеру */
+/* РџРѕР»СѓС‡РёС‚СЊ РѕРїРёСЃР°РЅРёРµ РѕС€РёР±РєРё РїРѕ РµРµ РЅРѕРјРµСЂСѓ */
 AS3_Val QSPGetErrorDesc(void *param, AS3_Val args)
 {
 	int errorNum;
@@ -540,9 +540,9 @@ AS3_Val QSPGetErrorDesc(void *param, AS3_Val args)
 	return res;
 }
 /* ------------------------------------------------------------ */
-/* Управление игрой */
+/* РЈРїСЂР°РІР»РµРЅРёРµ РёРіСЂРѕР№ */
 
-/* Загрузка новой игры из файла */
+/* Р—Р°РіСЂСѓР·РєР° РЅРѕРІРѕР№ РёРіСЂС‹ РёР· С„Р°Р№Р»Р° */
 AS3_Val QSPLoadGameWorld(void *param, AS3_Val args)
 {
 	char *fileName;
@@ -557,7 +557,7 @@ AS3_Val QSPLoadGameWorld(void *param, AS3_Val args)
 	if (qspErrorNum) return AS3_False();
 	return AS3_True();
 }
-/* Загрузка новой игры из памяти */
+/* Р—Р°РіСЂСѓР·РєР° РЅРѕРІРѕР№ РёРіСЂС‹ РёР· РїР°РјСЏС‚Рё */
 AS3_Val QSPLoadGameWorldFromData(void *param, AS3_Val args)
 {
 	char *ptr;
@@ -580,7 +580,7 @@ AS3_Val QSPLoadGameWorldFromData(void *param, AS3_Val args)
 	if (qspErrorNum) return AS3_False();
 	return AS3_True();
 }
-/* Сохранение состояния в файл */
+/* РЎРѕС…СЂР°РЅРµРЅРёРµ СЃРѕСЃС‚РѕСЏРЅРёСЏ РІ С„Р°Р№Р» */
 AS3_Val QSPSaveGame(void *param, AS3_Val args)
 {
 	char *fileName;
@@ -597,7 +597,7 @@ AS3_Val QSPSaveGame(void *param, AS3_Val args)
 	if (isRefresh) qspCallRefreshInt(QSP_FALSE);
 	return AS3_True();
 }
-/* Сохранение состояния в память */
+/* РЎРѕС…СЂР°РЅРµРЅРёРµ СЃРѕСЃС‚РѕСЏРЅРёСЏ РІ РїР°РјСЏС‚СЊ */
 AS3_Val QSPSaveGameAsData(void *param, AS3_Val args)
 {
 	int len;
@@ -615,7 +615,7 @@ AS3_Val QSPSaveGameAsData(void *param, AS3_Val args)
 	if (isRefresh) qspCallRefreshInt(QSP_FALSE);
 	return AS3_True();
 }
-/* Загрузка состояния из файла */
+/* Р—Р°РіСЂСѓР·РєР° СЃРѕСЃС‚РѕСЏРЅРёСЏ РёР· С„Р°Р№Р»Р° */
 AS3_Val QSPOpenSavedGame(void *param, AS3_Val args)
 {
 	char *fileName;
@@ -632,7 +632,7 @@ AS3_Val QSPOpenSavedGame(void *param, AS3_Val args)
 	if (isRefresh) qspCallRefreshInt(QSP_FALSE);
 	return AS3_True();
 }
-/* Загрузка состояния из памяти */
+/* Р—Р°РіСЂСѓР·РєР° СЃРѕСЃС‚РѕСЏРЅРёСЏ РёР· РїР°РјСЏС‚Рё */
 AS3_Val QSPOpenSavedGameFromData(void *param, AS3_Val args)
 {
 	AS3_Val data;
@@ -654,7 +654,7 @@ AS3_Val QSPOpenSavedGameFromData(void *param, AS3_Val args)
 	if (isRefresh) qspCallRefreshInt(QSP_FALSE);
 	return AS3_True();
 }
-/* Перезапуск игры */
+/* РџРµСЂРµР·Р°РїСѓСЃРє РёРіСЂС‹ */
 AS3_Val QSPRestartGame(void *param, AS3_Val args)
 {
 	QSP_BOOL isRefresh;
@@ -668,7 +668,7 @@ AS3_Val QSPRestartGame(void *param, AS3_Val args)
 	return AS3_True();
 }
 /* ------------------------------------------------------------ */
-/* Установка CALLBACK'ов */
+/* РЈСЃС‚Р°РЅРѕРІРєР° CALLBACK'РѕРІ */
 AS3_Val QSPSetCallBack(void *param, AS3_Val args)
 {
 	int type;
@@ -682,7 +682,7 @@ AS3_Val QSPSetCallBack(void *param, AS3_Val args)
 	return AS3_True();
 }
 /* ------------------------------------------------------------ */
-/* Инициализация */
+/* РРЅРёС†РёР°Р»РёР·Р°С†РёСЏ */
 AS3_Val QSPInit(void *param, AS3_Val args)
 {
 #ifdef _DEBUG
@@ -712,7 +712,7 @@ AS3_Val QSPInit(void *param, AS3_Val args)
 	qspInitMath();
 	return AS3_True();
 }
-/* Деинициализация */
+/* Р”РµРёРЅРёС†РёР°Р»РёР·Р°С†РёСЏ */
 AS3_Val QSPDeInit(void *param, AS3_Val args)
 {
 	qspMemClear(QSP_FALSE);

--- a/qsp/bindings/java/java_callbacks.c
+++ b/qsp/bindings/java/java_callbacks.c
@@ -45,7 +45,7 @@ void qspSetCallBack(int type, QSP_CALLBACK func)
 
 void qspCallDebug(QSP_CHAR *str)
 {
-	/* Здесь передаем управление отладчику */
+	/* Р—РґРµСЃСЊ РїРµСЂРµРґР°РµРј СѓРїСЂР°РІР»РµРЅРёРµ РѕС‚Р»Р°РґС‡РёРєСѓ */
 	QSPCallState state;
 	if (qspCallBacks[QSP_CALL_DEBUG])
 	{
@@ -57,7 +57,7 @@ void qspCallDebug(QSP_CHAR *str)
 
 void qspCallSetTimer(int msecs)
 {
-	/* Здесь устанавливаем интервал таймера */
+	/* Р—РґРµСЃСЊ СѓСЃС‚Р°РЅР°РІР»РёРІР°РµРј РёРЅС‚РµСЂРІР°Р» С‚Р°Р№РјРµСЂР° */
 	QSPCallState state;
 	if (qspCallBacks[QSP_CALL_SETTIMER])
 	{
@@ -69,7 +69,7 @@ void qspCallSetTimer(int msecs)
 
 void qspCallRefreshInt(QSP_BOOL isRedraw)
 {
-	/* Здесь выполняем обновление интерфейса */
+	/* Р—РґРµСЃСЊ РІС‹РїРѕР»РЅСЏРµРј РѕР±РЅРѕРІР»РµРЅРёРµ РёРЅС‚РµСЂС„РµР№СЃР° */
 	QSPCallState state;
 	if (qspCallBacks[QSP_CALL_REFRESHINT])
 	{
@@ -81,7 +81,7 @@ void qspCallRefreshInt(QSP_BOOL isRedraw)
 
 void qspCallSetInputStrText(QSP_CHAR *text)
 {
-	/* Здесь устанавливаем текст строки ввода */
+	/* Р—РґРµСЃСЊ СѓСЃС‚Р°РЅР°РІР»РёРІР°РµРј С‚РµРєСЃС‚ СЃС‚СЂРѕРєРё РІРІРѕРґР° */
 	QSPCallState state;
 	if (qspCallBacks[QSP_CALL_SETINPUTSTRTEXT])
 	{
@@ -93,7 +93,7 @@ void qspCallSetInputStrText(QSP_CHAR *text)
 
 void qspCallAddMenuItem(QSP_CHAR *name, QSP_CHAR *imgPath)
 {
-	/* Здесь добавляем пункт меню */
+	/* Р—РґРµСЃСЊ РґРѕР±Р°РІР»СЏРµРј РїСѓРЅРєС‚ РјРµРЅСЋ */
 	QSPCallState state;
 	if (qspCallBacks[QSP_CALL_ADDMENUITEM])
 	{
@@ -105,7 +105,7 @@ void qspCallAddMenuItem(QSP_CHAR *name, QSP_CHAR *imgPath)
 
 void qspCallSystem(QSP_CHAR *cmd)
 {
-	/* Здесь выполняем системный вызов */
+	/* Р—РґРµСЃСЊ РІС‹РїРѕР»РЅСЏРµРј СЃРёСЃС‚РµРјРЅС‹Р№ РІС‹Р·РѕРІ */
 	QSPCallState state;
 	if (qspCallBacks[QSP_CALL_SYSTEM])
 	{
@@ -117,8 +117,8 @@ void qspCallSystem(QSP_CHAR *cmd)
 
 void qspCallOpenGameStatus(QSP_CHAR *file)
 {
-	/* Здесь позволяем пользователю выбрать файл */
-	/* состояния игры для загрузки и загружаем его */
+	/* Р—РґРµСЃСЊ РїРѕР·РІРѕР»СЏРµРј РїРѕР»СЊР·РѕРІР°С‚РµР»СЋ РІС‹Р±СЂР°С‚СЊ С„Р°Р№Р» */
+	/* СЃРѕСЃС‚РѕСЏРЅРёСЏ РёРіСЂС‹ РґР»СЏ Р·Р°РіСЂСѓР·РєРё Рё Р·Р°РіСЂСѓР¶Р°РµРј РµРіРѕ */
 	QSPCallState state;
 	if (qspCallBacks[QSP_CALL_OPENGAMESTATUS])
 	{
@@ -130,9 +130,9 @@ void qspCallOpenGameStatus(QSP_CHAR *file)
 
 void qspCallSaveGameStatus(QSP_CHAR *file)
 {
-	/* Здесь позволяем пользователю выбрать файл */
-	/* для сохранения состояния игры и сохраняем */
-	/* в нем текущее состояние */
+	/* Р—РґРµСЃСЊ РїРѕР·РІРѕР»СЏРµРј РїРѕР»СЊР·РѕРІР°С‚РµР»СЋ РІС‹Р±СЂР°С‚СЊ С„Р°Р№Р» */
+	/* РґР»СЏ СЃРѕС…СЂР°РЅРµРЅРёСЏ СЃРѕСЃС‚РѕСЏРЅРёСЏ РёРіСЂС‹ Рё СЃРѕС…СЂР°РЅСЏРµРј */
+	/* РІ РЅРµРј С‚РµРєСѓС‰РµРµ СЃРѕСЃС‚РѕСЏРЅРёРµ */
 	QSPCallState state;
 	if (qspCallBacks[QSP_CALL_SAVEGAMESTATUS])
 	{
@@ -144,7 +144,7 @@ void qspCallSaveGameStatus(QSP_CHAR *file)
 
 void qspCallShowMessage(QSP_CHAR *text)
 {
-	/* Здесь показываем сообщение */
+	/* Р—РґРµСЃСЊ РїРѕРєР°Р·С‹РІР°РµРј СЃРѕРѕР±С‰РµРЅРёРµ */
 	QSPCallState state;
 	if (qspCallBacks[QSP_CALL_SHOWMSGSTR])
 	{
@@ -156,7 +156,7 @@ void qspCallShowMessage(QSP_CHAR *text)
 
 int qspCallShowMenu()
 {
-	/* Здесь показываем меню */
+	/* Р—РґРµСЃСЊ РїРѕРєР°Р·С‹РІР°РµРј РјРµРЅСЋ */
 	QSPCallState state;
 	int index;
 	if (qspCallBacks[QSP_CALL_SHOWMENU])
@@ -171,7 +171,7 @@ int qspCallShowMenu()
 
 void qspCallShowPicture(QSP_CHAR *file)
 {
-	/* Здесь показываем изображение */
+	/* Р—РґРµСЃСЊ РїРѕРєР°Р·С‹РІР°РµРј РёР·РѕР±СЂР°Р¶РµРЅРёРµ */
 	QSPCallState state;
 	if (qspCallBacks[QSP_CALL_SHOWIMAGE])
 	{
@@ -183,7 +183,7 @@ void qspCallShowPicture(QSP_CHAR *file)
 
 void qspCallShowWindow(int type, QSP_BOOL isShow)
 {
-	/* Здесь показываем или скрываем окно */
+	/* Р—РґРµСЃСЊ РїРѕРєР°Р·С‹РІР°РµРј РёР»Рё СЃРєСЂС‹РІР°РµРј РѕРєРЅРѕ */
 	QSPCallState state;
 	if (qspCallBacks[QSP_CALL_SHOWWINDOW])
 	{
@@ -195,7 +195,7 @@ void qspCallShowWindow(int type, QSP_BOOL isShow)
 
 void qspCallPlayFile(QSP_CHAR *file, int volume)
 {
-	/* Здесь начинаем воспроизведение файла с заданной громкостью */
+	/* Р—РґРµСЃСЊ РЅР°С‡РёРЅР°РµРј РІРѕСЃРїСЂРѕРёР·РІРµРґРµРЅРёРµ С„Р°Р№Р»Р° СЃ Р·Р°РґР°РЅРЅРѕР№ РіСЂРѕРјРєРѕСЃС‚СЊСЋ */
 	QSPCallState state;
 	if (qspCallBacks[QSP_CALL_PLAYFILE])
 	{
@@ -207,7 +207,7 @@ void qspCallPlayFile(QSP_CHAR *file, int volume)
 
 QSP_BOOL qspCallIsPlayingFile(QSP_CHAR *file)
 {
-	/* Здесь проверяем, проигрывается ли файл */
+	/* Р—РґРµСЃСЊ РїСЂРѕРІРµСЂСЏРµРј, РїСЂРѕРёРіСЂС‹РІР°РµС‚СЃСЏ Р»Рё С„Р°Р№Р» */
 	QSPCallState state;
 	QSP_BOOL isPlaying;
 	if (qspCallBacks[QSP_CALL_ISPLAYINGFILE])
@@ -222,7 +222,7 @@ QSP_BOOL qspCallIsPlayingFile(QSP_CHAR *file)
 
 void qspCallSleep(int msecs)
 {
-	/* Здесь ожидаем заданное количество миллисекунд */
+	/* Р—РґРµСЃСЊ РѕР¶РёРґР°РµРј Р·Р°РґР°РЅРЅРѕРµ РєРѕР»РёС‡РµСЃС‚РІРѕ РјРёР»Р»РёСЃРµРєСѓРЅРґ */
 	QSPCallState state;
 	if (qspCallBacks[QSP_CALL_SLEEP])
 	{
@@ -234,7 +234,7 @@ void qspCallSleep(int msecs)
 
 int qspCallGetMSCount()
 {
-	/* Здесь получаем количество миллисекунд, прошедших с момента последнего вызова функции */
+	/* Р—РґРµСЃСЊ РїРѕР»СѓС‡Р°РµРј РєРѕР»РёС‡РµСЃС‚РІРѕ РјРёР»Р»РёСЃРµРєСѓРЅРґ, РїСЂРѕС€РµРґС€РёС… СЃ РјРѕРјРµРЅС‚Р° РїРѕСЃР»РµРґРЅРµРіРѕ РІС‹Р·РѕРІР° С„СѓРЅРєС†РёРё */
 	QSPCallState state;
 	int count;
 	if (qspCallBacks[QSP_CALL_GETMSCOUNT])
@@ -249,7 +249,7 @@ int qspCallGetMSCount()
 
 void qspCallCloseFile(QSP_CHAR *file)
 {
-	/* Здесь выполняем закрытие файла */
+	/* Р—РґРµСЃСЊ РІС‹РїРѕР»РЅСЏРµРј Р·Р°РєСЂС‹С‚РёРµ С„Р°Р№Р»Р° */
 	QSPCallState state;
 	if (qspCallBacks[QSP_CALL_CLOSEFILE])
 	{
@@ -261,7 +261,7 @@ void qspCallCloseFile(QSP_CHAR *file)
 
 void qspCallDeleteMenu()
 {
-	/* Здесь удаляем текущее меню */
+	/* Р—РґРµСЃСЊ СѓРґР°Р»СЏРµРј С‚РµРєСѓС‰РµРµ РјРµРЅСЋ */
 	QSPCallState state;
 	if (qspCallBacks[QSP_CALL_DELETEMENU])
 	{
@@ -273,7 +273,7 @@ void qspCallDeleteMenu()
 
 QSPString qspCallInputBox(QSPString text)
 {
-	/* Здесь вводим текст */
+	/* Р—РґРµСЃСЊ РІРІРѕРґРёРј С‚РµРєСЃС‚ */
 	QSPCallState state;
 	QSP_CHAR *buffer;
 	int maxLen = 511;

--- a/qsp/bindings/java/java_control.c
+++ b/qsp/bindings/java/java_control.c
@@ -41,14 +41,14 @@ void QSPIsInCallBack(QSP_BOOL *res)
 	*res = qspIsInCallBack;
 }
 /* ------------------------------------------------------------ */
-/* Отладка */
+/* РћС‚Р»Р°РґРєР° */
 
-/* Управление режимом отладки */
+/* РЈРїСЂР°РІР»РµРЅРёРµ СЂРµР¶РёРјРѕРј РѕС‚Р»Р°РґРєРё */
 void QSPEnableDebugMode(QSP_BOOL isDebug)
 {
 	qspIsDebug = isDebug;
 }
-/* Получение данных текущего состояния */
+/* РџРѕР»СѓС‡РµРЅРёРµ РґР°РЅРЅС‹С… С‚РµРєСѓС‰РµРіРѕ СЃРѕСЃС‚РѕСЏРЅРёСЏ */
 void QSPGetCurStateData(QSP_CHAR **loc, int *actIndex, int *line)
 {
 	*loc = (qspRealCurLoc >= 0 && qspRealCurLoc < qspLocsCount ? qspLocs[qspRealCurLoc].Name : 0);
@@ -56,64 +56,64 @@ void QSPGetCurStateData(QSP_CHAR **loc, int *actIndex, int *line)
 	*line = qspRealLine;
 }
 /* ------------------------------------------------------------ */
-/* Информация о версии */
+/* РРЅС„РѕСЂРјР°С†РёСЏ Рѕ РІРµСЂСЃРёРё */
 
-/* Версия */
+/* Р’РµСЂСЃРёСЏ */
 void QSPGetVersion(const QSP_CHAR* *res)
 {
 	*res = QSP_VER;
 }
-/* Дата и время компиляции */
+/* Р”Р°С‚Р° Рё РІСЂРµРјСЏ РєРѕРјРїРёР»СЏС†РёРё */
 void QSPGetCompiledDateTime(const QSP_CHAR* *res)
 {
 	*res = QSP_FMT(__DATE__) QSP_FMT(", ") QSP_FMT(__TIME__);
 }
 /* ------------------------------------------------------------ */
-/* Количество полных обновлений локаций */
+/* РљРѕР»РёС‡РµСЃС‚РІРѕ РїРѕР»РЅС‹С… РѕР±РЅРѕРІР»РµРЅРёР№ Р»РѕРєР°С†РёР№ */
 void QSPGetFullRefreshCount(int *res)
 {
 	*res = qspFullRefreshCount;
 }
 /* ------------------------------------------------------------ */
-/* Полный путь к загруженному файлу игры */
+/* РџРѕР»РЅС‹Р№ РїСѓС‚СЊ Рє Р·Р°РіСЂСѓР¶РµРЅРЅРѕРјСѓ С„Р°Р№Р»Сѓ РёРіСЂС‹ */
 void QSPGetQstFullPath(const QSP_CHAR* *res)
 {
 	*res = qspQstFullPath;
 }
 /* ------------------------------------------------------------ */
-/* Название текущей локации */
+/* РќР°Р·РІР°РЅРёРµ С‚РµРєСѓС‰РµР№ Р»РѕРєР°С†РёРё */
 void QSPGetCurLoc(const QSP_CHAR* *res)
 {
 	*res = (qspCurLoc >= 0 ? qspLocs[qspCurLoc].Name : 0);
 }
 /* ------------------------------------------------------------ */
-/* Основное описание локации */
+/* РћСЃРЅРѕРІРЅРѕРµ РѕРїРёСЃР°РЅРёРµ Р»РѕРєР°С†РёРё */
 
-/* Текст основного окна описания локации */
+/* РўРµРєСЃС‚ РѕСЃРЅРѕРІРЅРѕРіРѕ РѕРєРЅР° РѕРїРёСЃР°РЅРёСЏ Р»РѕРєР°С†РёРё */
 void QSPGetMainDesc(const QSP_CHAR* *res)
 {
 	*res = qspCurDesc;
 }
-/* Возможность изменения текста основного описания */
+/* Р’РѕР·РјРѕР¶РЅРѕСЃС‚СЊ РёР·РјРµРЅРµРЅРёСЏ С‚РµРєСЃС‚Р° РѕСЃРЅРѕРІРЅРѕРіРѕ РѕРїРёСЃР°РЅРёСЏ */
 void QSPIsMainDescChanged(QSP_BOOL *res)
 {
 	*res = qspIsMainDescChanged;
 }
 /* ------------------------------------------------------------ */
-/* Дополнительное описание локации */
+/* Р”РѕРїРѕР»РЅРёС‚РµР»СЊРЅРѕРµ РѕРїРёСЃР°РЅРёРµ Р»РѕРєР°С†РёРё */
 
-/* Текст дополнительного окна описания локации */
+/* РўРµРєСЃС‚ РґРѕРїРѕР»РЅРёС‚РµР»СЊРЅРѕРіРѕ РѕРєРЅР° РѕРїРёСЃР°РЅРёСЏ Р»РѕРєР°С†РёРё */
 void QSPGetVarsDesc(const QSP_CHAR* *res)
 {
 	*res = qspCurVars;
 }
-/* Возможность изменения текста дополнительного описания */
+/* Р’РѕР·РјРѕР¶РЅРѕСЃС‚СЊ РёР·РјРµРЅРµРЅРёСЏ С‚РµРєСЃС‚Р° РґРѕРїРѕР»РЅРёС‚РµР»СЊРЅРѕРіРѕ РѕРїРёСЃР°РЅРёСЏ */
 void QSPIsVarsDescChanged(QSP_BOOL *res)
 {
 	*res = qspIsVarsDescChanged;
 }
 /* ------------------------------------------------------------ */
-/* Получить значение указанного выражения */
+/* РџРѕР»СѓС‡РёС‚СЊ Р·РЅР°С‡РµРЅРёРµ СѓРєР°Р·Р°РЅРЅРѕРіРѕ РІС‹СЂР°Р¶РµРЅРёСЏ */
 void QSPGetExprValue(QSP_BOOL *res, const QSP_CHAR *expr, QSP_BOOL *isString, int *numVal, QSP_CHAR *strVal, int strValBufSize)
 {
 	QSPVariant v;
@@ -146,20 +146,20 @@ void QSPGetExprValue(QSP_BOOL *res, const QSP_CHAR *expr, QSP_BOOL *isString, in
 	*res = QSP_TRUE;
 }
 /* ------------------------------------------------------------ */
-/* Текст строки ввода */
+/* РўРµРєСЃС‚ СЃС‚СЂРѕРєРё РІРІРѕРґР° */
 void QSPSetInputStrText(const QSP_CHAR *val)
 {
 	qspCurInputLen = qspAddText(&qspCurInput, (QSP_CHAR *)val, 0, -1, QSP_FALSE);
 }
 /* ------------------------------------------------------------ */
-/* Список действий */
+/* РЎРїРёСЃРѕРє РґРµР№СЃС‚РІРёР№ */
 
-/* Количество действий */
+/* РљРѕР»РёС‡РµСЃС‚РІРѕ РґРµР№СЃС‚РІРёР№ */
 void QSPGetActionsCount(int* res)
 {
 	*res = qspCurActionsCount;
 }
-/* Данные действия с указанным индексом */
+/* Р”Р°РЅРЅС‹Рµ РґРµР№СЃС‚РІРёСЏ СЃ СѓРєР°Р·Р°РЅРЅС‹Рј РёРЅРґРµРєСЃРѕРј */
 void QSPGetActionData(int ind, QSP_CHAR **image, QSP_CHAR **desc)
 {
 	if (ind >= 0 && ind < qspCurActionsCount)
@@ -170,7 +170,7 @@ void QSPGetActionData(int ind, QSP_CHAR **image, QSP_CHAR **desc)
 	else
 		*image = *desc = 0;
 }
-/* Выполнение кода выбранного действия */
+/* Р’С‹РїРѕР»РЅРµРЅРёРµ РєРѕРґР° РІС‹Р±СЂР°РЅРЅРѕРіРѕ РґРµР№СЃС‚РІРёСЏ */
 void QSPExecuteSelActionCode(QSP_BOOL *res, QSP_BOOL isRefresh)
 {
 	if (qspCurSelAction >= 0)
@@ -196,7 +196,7 @@ void QSPExecuteSelActionCode(QSP_BOOL *res, QSP_BOOL isRefresh)
 	}
 	*res = QSP_TRUE;
 }
-/* Установить индекс выбранного действия */
+/* РЈСЃС‚Р°РЅРѕРІРёС‚СЊ РёРЅРґРµРєСЃ РІС‹Р±СЂР°РЅРЅРѕРіРѕ РґРµР№СЃС‚РІРёСЏ */
 void QSPSetSelActionIndex(QSP_BOOL *res, int ind, QSP_BOOL isRefresh)
 {
 	if (ind >= 0 && ind < qspCurActionsCount && ind != qspCurSelAction)
@@ -223,25 +223,25 @@ void QSPSetSelActionIndex(QSP_BOOL *res, int ind, QSP_BOOL isRefresh)
 	}
 	*res = QSP_TRUE;
 }
-/* Получить индекс выбранного действия */
+/* РџРѕР»СѓС‡РёС‚СЊ РёРЅРґРµРєСЃ РІС‹Р±СЂР°РЅРЅРѕРіРѕ РґРµР№СЃС‚РІРёСЏ */
 void QSPGetSelActionIndex(int *res)
 {
 	*res = qspCurSelAction;
 }
-/* Возможность изменения списка действий */
+/* Р’РѕР·РјРѕР¶РЅРѕСЃС‚СЊ РёР·РјРµРЅРµРЅРёСЏ СЃРїРёСЃРєР° РґРµР№СЃС‚РІРёР№ */
 void QSPIsActionsChanged(QSP_BOOL *res)
 {
 	*res = qspIsActionsChanged;
 }
 /* ------------------------------------------------------------ */
-/* Список объектов */
+/* РЎРїРёСЃРѕРє РѕР±СЉРµРєС‚РѕРІ */
 
-/* Количество объектов */
+/* РљРѕР»РёС‡РµСЃС‚РІРѕ РѕР±СЉРµРєС‚РѕРІ */
 void QSPGetObjectsCount(int *res)
 {
 	*res = qspCurObjectsCount;
 }
-/* Данные объекта с указанным индексом */
+/* Р”Р°РЅРЅС‹Рµ РѕР±СЉРµРєС‚Р° СЃ СѓРєР°Р·Р°РЅРЅС‹Рј РёРЅРґРµРєСЃРѕРј */
 void QSPGetObjectData(int ind, QSP_CHAR **image, QSP_CHAR **desc)
 {
 	if (ind >= 0 && ind < qspCurObjectsCount)
@@ -252,7 +252,7 @@ void QSPGetObjectData(int ind, QSP_CHAR **image, QSP_CHAR **desc)
 	else
 		*image = *desc = 0;
 }
-/* Установить индекс выбранного объекта */
+/* РЈСЃС‚Р°РЅРѕРІРёС‚СЊ РёРЅРґРµРєСЃ РІС‹Р±СЂР°РЅРЅРѕРіРѕ РѕР±СЉРµРєС‚Р° */
 void QSPSetSelObjectIndex(QSP_BOOL *res, int ind, QSP_BOOL isRefresh)
 {
 	if (ind >= 0 && ind < qspCurObjectsCount && ind != qspCurSelObject)
@@ -279,18 +279,18 @@ void QSPSetSelObjectIndex(QSP_BOOL *res, int ind, QSP_BOOL isRefresh)
 	}
 	*res = QSP_TRUE;
 }
-/* Получить индекс выбранного объекта */
+/* РџРѕР»СѓС‡РёС‚СЊ РёРЅРґРµРєСЃ РІС‹Р±СЂР°РЅРЅРѕРіРѕ РѕР±СЉРµРєС‚Р° */
 void QSPGetSelObjectIndex(int* res)
 {
 	*res = qspCurSelObject;
 }
-/* Возможность изменения списка объектов */
+/* Р’РѕР·РјРѕР¶РЅРѕСЃС‚СЊ РёР·РјРµРЅРµРЅРёСЏ СЃРїРёСЃРєР° РѕР±СЉРµРєС‚РѕРІ */
 void QSPIsObjectsChanged(QSP_BOOL *res)
 {
 	*res = qspIsObjectsChanged;
 }
 /* ------------------------------------------------------------ */
-/* Показ / скрытие окон */
+/* РџРѕРєР°Р· / СЃРєСЂС‹С‚РёРµ РѕРєРѕРЅ */
 void QSPShowWindow(int type, QSP_BOOL isShow)
 {
 	switch (type)
@@ -310,9 +310,9 @@ void QSPShowWindow(int type, QSP_BOOL isShow)
 	}
 }
 /* ------------------------------------------------------------ */
-/* Переменные */
+/* РџРµСЂРµРјРµРЅРЅС‹Рµ */
 
-/* Получить количество элементов массива */
+/* РџРѕР»СѓС‡РёС‚СЊ РєРѕР»РёС‡РµСЃС‚РІРѕ СЌР»РµРјРµРЅС‚РѕРІ РјР°СЃСЃРёРІР° */
 void QSPGetVarValuesCount(QSP_BOOL *res, const QSP_CHAR *name, int *count)
 {
 	QSPVar *var;
@@ -331,7 +331,7 @@ void QSPGetVarValuesCount(QSP_BOOL *res, const QSP_CHAR *name, int *count)
 	*count = var->ValsCount;
 	*res = QSP_TRUE;
 }
-/* Получить значения указанного элемента массива */
+/* РџРѕР»СѓС‡РёС‚СЊ Р·РЅР°С‡РµРЅРёСЏ СѓРєР°Р·Р°РЅРЅРѕРіРѕ СЌР»РµРјРµРЅС‚Р° РјР°СЃСЃРёРІР° */
 void QSPGetVarValues(QSP_BOOL *res, const QSP_CHAR *name, int ind, int *numVal, QSP_CHAR **strVal)
 {
 	QSPVar *var;
@@ -351,12 +351,12 @@ void QSPGetVarValues(QSP_BOOL *res, const QSP_CHAR *name, int ind, int *numVal, 
 	*strVal = var->Values[ind].Str;
 	*res = QSP_TRUE;
 }
-/* Получить максимальное количество переменных */
+/* РџРѕР»СѓС‡РёС‚СЊ РјР°РєСЃРёРјР°Р»СЊРЅРѕРµ РєРѕР»РёС‡РµСЃС‚РІРѕ РїРµСЂРµРјРµРЅРЅС‹С… */
 void QSPGetMaxVarsCount(int *res)
 {
 	*res = QSP_VARSCOUNT;
 }
-/* Получить имя переменной с указанным индексом */
+/* РџРѕР»СѓС‡РёС‚СЊ РёРјСЏ РїРµСЂРµРјРµРЅРЅРѕР№ СЃ СѓРєР°Р·Р°РЅРЅС‹Рј РёРЅРґРµРєСЃРѕРј */
 void QSPGetVarNameByIndex(QSP_BOOL *res, int index, QSP_CHAR **name)
 {
 	if (index < 0 || index >= QSP_VARSCOUNT || !qspVars[index].Name)
@@ -368,9 +368,9 @@ void QSPGetVarNameByIndex(QSP_BOOL *res, int index, QSP_CHAR **name)
 	*res = QSP_TRUE;
 }
 /* ------------------------------------------------------------ */
-/* Выполнение кода */
+/* Р’С‹РїРѕР»РЅРµРЅРёРµ РєРѕРґР° */
 
-/* Выполнение строки кода */
+/* Р’С‹РїРѕР»РЅРµРЅРёРµ СЃС‚СЂРѕРєРё РєРѕРґР° */
 void QSPExecString(QSP_BOOL *res, const QSP_CHAR *s, QSP_BOOL isRefresh)
 {
 	if (qspIsExitOnError && qspErrorNum)
@@ -393,7 +393,7 @@ void QSPExecString(QSP_BOOL *res, const QSP_CHAR *s, QSP_BOOL isRefresh)
 	if (isRefresh) qspCallRefreshInt(QSP_FALSE);
 	*res = QSP_TRUE;
 }
-/* Выполнение кода указанной локации */
+/* Р’С‹РїРѕР»РЅРµРЅРёРµ РєРѕРґР° СѓРєР°Р·Р°РЅРЅРѕР№ Р»РѕРєР°С†РёРё */
 void QSPExecLocationCode(QSP_BOOL *res, const QSP_CHAR *name, QSP_BOOL isRefresh)
 {
 	if (qspIsExitOnError && qspErrorNum)
@@ -416,7 +416,7 @@ void QSPExecLocationCode(QSP_BOOL *res, const QSP_CHAR *name, QSP_BOOL isRefresh
 	if (isRefresh) qspCallRefreshInt(QSP_FALSE);
 	*res = QSP_TRUE;
 }
-/* Выполнение кода локации-счетчика */
+/* Р’С‹РїРѕР»РЅРµРЅРёРµ РєРѕРґР° Р»РѕРєР°С†РёРё-СЃС‡РµС‚С‡РёРєР° */
 void QSPExecCounter(QSP_BOOL *res, QSP_BOOL isRefresh)
 {
 	if (!qspIsInCallBack)
@@ -432,7 +432,7 @@ void QSPExecCounter(QSP_BOOL *res, QSP_BOOL isRefresh)
 	}
 	*res = QSP_TRUE;
 }
-/* Выполнение кода локации-обработчика строки ввода */
+/* Р’С‹РїРѕР»РЅРµРЅРёРµ РєРѕРґР° Р»РѕРєР°С†РёРё-РѕР±СЂР°Р±РѕС‚С‡РёРєР° СЃС‚СЂРѕРєРё РІРІРѕРґР° */
 void QSPExecUserInput(QSP_BOOL *res, QSP_BOOL isRefresh)
 {
 	if (qspIsExitOnError && qspErrorNum)
@@ -456,9 +456,9 @@ void QSPExecUserInput(QSP_BOOL *res, QSP_BOOL isRefresh)
 	*res = QSP_TRUE;
 }
 /* ------------------------------------------------------------ */
-/* Ошибки */
+/* РћС€РёР±РєРё */
 
-/* Получить информацию о последней ошибке */
+/* РџРѕР»СѓС‡РёС‚СЊ РёРЅС„РѕСЂРјР°С†РёСЋ Рѕ РїРѕСЃР»РµРґРЅРµР№ РѕС€РёР±РєРµ */
 void QSPGetLastErrorData(int *errorNum, QSP_CHAR **errorLoc, int *errorActIndex, int *errorLine)
 {
 	*errorNum = qspErrorNum;
@@ -466,15 +466,15 @@ void QSPGetLastErrorData(int *errorNum, QSP_CHAR **errorLoc, int *errorActIndex,
 	*errorActIndex = qspErrorActIndex;
 	*errorLine = qspErrorLine;
 }
-/* Получить описание ошибки по ее номеру */
+/* РџРѕР»СѓС‡РёС‚СЊ РѕРїРёСЃР°РЅРёРµ РѕС€РёР±РєРё РїРѕ РµРµ РЅРѕРјРµСЂСѓ */
 void QSPGetErrorDesc(const QSP_CHAR* *res, int errorNum)
 {
 	*res = qspGetErrorDesc(errorNum);
 }
 /* ------------------------------------------------------------ */
-/* Управление игрой */
+/* РЈРїСЂР°РІР»РµРЅРёРµ РёРіСЂРѕР№ */
 
-/* Загрузка новой игры из файла */
+/* Р—Р°РіСЂСѓР·РєР° РЅРѕРІРѕР№ РёРіСЂС‹ РёР· С„Р°Р№Р»Р° */
 void QSPLoadGameWorld(QSP_BOOL *res, const QSP_CHAR *fileName)
 {
 	if (qspIsExitOnError && qspErrorNum)
@@ -496,7 +496,7 @@ void QSPLoadGameWorld(QSP_BOOL *res, const QSP_CHAR *fileName)
 	}
 	*res = QSP_TRUE;
 }
-/* Загрузка новой игры из памяти */
+/* Р—Р°РіСЂСѓР·РєР° РЅРѕРІРѕР№ РёРіСЂС‹ РёР· РїР°РјСЏС‚Рё */
 void QSPLoadGameWorldFromData(QSP_BOOL *res, const void *data, int dataSize, const QSP_CHAR *fileName)
 {
 	char *ptr;
@@ -523,7 +523,7 @@ void QSPLoadGameWorldFromData(QSP_BOOL *res, const void *data, int dataSize, con
 	}
 	*res = QSP_TRUE;
 }
-/* Сохранение состояния в файл */
+/* РЎРѕС…СЂР°РЅРµРЅРёРµ СЃРѕСЃС‚РѕСЏРЅРёСЏ РІ С„Р°Р№Р» */
 void QSPSaveGame(QSP_BOOL *res, const QSP_CHAR *fileName, QSP_BOOL isRefresh)
 {
 	if (qspIsExitOnError && qspErrorNum)
@@ -546,7 +546,7 @@ void QSPSaveGame(QSP_BOOL *res, const QSP_CHAR *fileName, QSP_BOOL isRefresh)
 	if (isRefresh) qspCallRefreshInt(QSP_FALSE);
 	*res = QSP_TRUE;
 }
-/* Сохранение состояния в память */
+/* РЎРѕС…СЂР°РЅРµРЅРёРµ СЃРѕСЃС‚РѕСЏРЅРёСЏ РІ РїР°РјСЏС‚СЊ */
 void QSPSaveGameAsData(QSP_BOOL *res, void *buf, int bufSize, int *realSize, QSP_BOOL isRefresh)
 {
 	int len, size;
@@ -581,7 +581,7 @@ void QSPSaveGameAsData(QSP_BOOL *res, void *buf, int bufSize, int *realSize, QSP
 	if (isRefresh) qspCallRefreshInt(QSP_FALSE);
 	*res = QSP_TRUE;
 }
-/* Загрузка состояния из файла */
+/* Р—Р°РіСЂСѓР·РєР° СЃРѕСЃС‚РѕСЏРЅРёСЏ РёР· С„Р°Р№Р»Р° */
 void QSPOpenSavedGame(QSP_BOOL *res, const QSP_CHAR *fileName, QSP_BOOL isRefresh)
 {
 	if (qspIsExitOnError && qspErrorNum)
@@ -604,7 +604,7 @@ void QSPOpenSavedGame(QSP_BOOL *res, const QSP_CHAR *fileName, QSP_BOOL isRefres
 	if (isRefresh) qspCallRefreshInt(QSP_FALSE);
 	*res = QSP_TRUE;
 }
-/* Загрузка состояния из памяти */
+/* Р—Р°РіСЂСѓР·РєР° СЃРѕСЃС‚РѕСЏРЅРёСЏ РёР· РїР°РјСЏС‚Рё */
 void QSPOpenSavedGameFromData(QSP_BOOL *res, const void *data, int dataSize, QSP_BOOL isRefresh)
 {
 	int dataLen;
@@ -634,7 +634,7 @@ void QSPOpenSavedGameFromData(QSP_BOOL *res, const void *data, int dataSize, QSP
 	if (isRefresh) qspCallRefreshInt(QSP_FALSE);
 	*res = QSP_TRUE;
 }
-/* Перезапуск игры */
+/* РџРµСЂРµР·Р°РїСѓСЃРє РёРіСЂС‹ */
 void QSPRestartGame(QSP_BOOL *res, QSP_BOOL isRefresh)
 {
 	if (qspIsExitOnError && qspErrorNum)
@@ -658,13 +658,13 @@ void QSPRestartGame(QSP_BOOL *res, QSP_BOOL isRefresh)
 	*res = QSP_TRUE;
 }
 /* ------------------------------------------------------------ */
-/* Установка CALLBACK'ов */
+/* РЈСЃС‚Р°РЅРѕРІРєР° CALLBACK'РѕРІ */
 void QSPSetCallBack(int type, QSP_CALLBACK func)
 {
 	qspSetCallBack(type, func);
 }
 /* ------------------------------------------------------------ */
-/* Инициализация */
+/* РРЅРёС†РёР°Р»РёР·Р°С†РёСЏ */
 void QSPInit()
 {
 	#ifdef _DEBUG
@@ -693,7 +693,7 @@ void QSPInit()
 	qspInitStats();
 	qspInitMath();
 }
-/* Деинициализация */
+/* Р”РµРёРЅРёС†РёР°Р»РёР·Р°С†РёСЏ */
 void QSPDeInit()
 {
 	qspMemClear(QSP_FALSE);

--- a/txt2gam/src/coding.h
+++ b/txt2gam/src/coding.h
@@ -22,15 +22,17 @@
 
 	#define QSP_CODREMOV 5
 
-	extern wchar_t qspCP1251ToUnicodeTable[];
+	extern wchar_t qspCP1251ToUCS2LETable[];
+	extern unsigned int qspCP1251ToUTF8Table[];
 
 	/* External functions */
-	wchar_t qspDirectConvertUC(char, wchar_t *);
-	char qspReverseConvertUC(wchar_t, wchar_t *);
+	wchar_t qspDirectConvertUC2LE(char, wchar_t *);
+	char qspReverseConvertUCS2LE(wchar_t, wchar_t *);
+	char qspReverseConvertUTF8(unsigned int, unsigned int *);
 	char *qspFromQSPString(QSP_CHAR *);
 	QSP_CHAR *qspToQSPString(char *);
 	char *qspQSPToGameString(QSP_CHAR *, QSP_BOOL, QSP_BOOL);
-	QSP_CHAR *qspGameToQSPString(char *, QSP_BOOL, QSP_BOOL);
+	QSP_CHAR *qspGameToQSPString(char *, encoding_t);
 	int qspSplitGameStr(char *, QSP_BOOL, QSP_CHAR *, char ***);
 	int qspGameCodeWriteIntVal(char **, int, int, QSP_BOOL, QSP_BOOL);
 	int qspGameCodeWriteVal(char **, int, QSP_CHAR *, QSP_BOOL, QSP_BOOL);

--- a/txt2gam/src/declarations.h
+++ b/txt2gam/src/declarations.h
@@ -46,10 +46,10 @@
 		#define QSP_WCSTOMBS wcstombs
 		#define QSP_MBSTOWCSLEN(a) mbstowcs(0, a, 0)
 		#define QSP_MBSTOWCS mbstowcs
-		#define QSP_FROM_OS_CHAR(a) qspReverseConvertUC(a, qspCP1251ToUnicodeTable)
-		#define QSP_TO_OS_CHAR(a) qspDirectConvertUC(a, qspCP1251ToUnicodeTable)
-		#define QSP_WCTOB
-		#define QSP_BTOWC
+		#define QSP_FROM_OS_CHAR(a) qspReverseConvertUCS2LE(a, qspCP1251ToUCS2LETable)
+		#define QSP_TO_OS_CHAR(a) qspDirectConvertUCS2LE(a, qspCP1251ToUCS2LETable)
+		#define QSP_UCS2TOB
+		#define QSP_BTOUCS2
 	#else
 		typedef char QSP_CHAR;
 		#define QSP_FMT(x) x
@@ -64,8 +64,8 @@
 		#define QSP_MBSTOWCS strncpy
 		#define QSP_FROM_OS_CHAR
 		#define QSP_TO_OS_CHAR
-		#define QSP_WCTOB(a) qspReverseConvertUC(a, qspCP1251ToUnicodeTable)
-		#define QSP_BTOWC(a) qspDirectConvertUC(a, qspCP1251ToUnicodeTable)
+		#define QSP_UCS2TOB(a) qspReverseConvertUCS2LE(a, qspCP1251ToUCS2LETable)
+		#define QSP_BTOUCS2(a) qspDirectConvertUCS2LE(a, qspCP1251ToUCS2LETable)
 	#endif
 
 	#define QSP_VER QSP_FMT("0.1.1")
@@ -74,7 +74,13 @@
 	#define QSP_TRUE 1
 	#define QSP_FALSE 0
 
+	#define QSP_BYTE(a) (a & 0xFF)
+	#define QSP_DWORD(a, b, c, d) (((a) & 0xFF) << 24) | (((b) & 0xFF) << 16) | (((c) & 0xFF) << 8) | ((d) & 0xFF)
+
+	#define QSP_UTF8TOB(a) qspReverseConvertUTF8(a, qspCP1251ToUTF8Table)
+
 	/* Types */
 	typedef int QSP_BOOL;
+	typedef enum _encoding { CP1251, UTF8, UCS2LE } encoding_t;
 
 #endif


### PR DESCRIPTION
* UCS-2 плохо поддерживается в текстовых редакторах под Android, в отличие от UTF-8
* В CMake-файл при желании легко можно добавить поддержку Unix, Mac, MinGW и более старых версий VS
* Версия wxWidgets в build_wx устарела и не могла быть собрана с использованием VS 2017